### PR TITLE
Add dockerfile for verified build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Get rust and solana toolchain
+FROM ellipsislabs/solana:latest
+# Download the phoenix-v1 source code
+RUN git clone https://github.com/Ellipsis-Labs/phoenix-v1.git /build
+# Checkout the commit that was used to build the binary
+RUN git checkout d66d2cddc7bcfd9fb3d89e5242e97f6928cd7361
+# Run the build script
+RUN cargo build-sbf -- --locked --frozen


### PR DESCRIPTION
This points to the published image at ellipsislabs/phoenix-v1:v0.1.1 

```
solana-verify verify-from-image -e target/deploy/phoenix.so -i ellipsislabs/phoenix-v1:v0.1.1 -p PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY -um
```

This will verify the program and print the following output 

```
Verifying image: "ellipsislabs/phoenix-v1:v0.1.1", on network Some("m") against program ID PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY
Executable path in container: "target/deploy/phoenix.so"

Executable hash: 4d22fa635c85547d0280e5165f5d0901bdf2b553efb2d9e95772a02b79530a9c
Program hash: 4d22fa635c85547d0280e5165f5d0901bdf2b553efb2d9e95772a02b79530a9c
Executable matches on-chain program data ✅
```