### PR TITLE
Time In Force

### DIFF
--- a/idl/phoenix_v1.json
+++ b/idl/phoenix_v1.json
@@ -1801,6 +1801,58 @@
       }
     },
     {
+      "name": "TimeInForceEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "orderSequenceNumber",
+            "type": "u64"
+          },
+          {
+            "name": "lastValidSlot",
+            "type": "u64"
+          },
+          {
+            "name": "lastValidUnixTimestampInSeconds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExpiredOrderEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "makerId",
+            "type": "publicKey"
+          },
+          {
+            "name": "orderSequenceNumber",
+            "type": "u64"
+          },
+          {
+            "name": "priceInTicks",
+            "type": "u64"
+          },
+          {
+            "name": "baseLotsRemoved",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "CancelUpToParams",
       "type": {
         "kind": "struct",
@@ -1950,6 +2002,18 @@
           {
             "name": "sizeInBaseLots",
             "type": "u64"
+          },
+          {
+            "name": "lastValidSlot",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "lastValidUnixTimestampInSeconds",
+            "type": {
+              "option": "u64"
+            }
           }
         ]
       }
@@ -2154,6 +2218,22 @@
             "fields": [
               {
                 "defined": "FeeEvent"
+              }
+            ]
+          },
+          {
+            "name": "TimeInForce",
+            "fields": [
+              {
+                "defined": "TimeInForceEvent"
+              }
+            ]
+          },
+          {
+            "name": "ExpiredOrder",
+            "fields": [
+              {
+                "defined": "ExpiredOrderEvent"
               }
             ]
           }

--- a/src/program/events.rs
+++ b/src/program/events.rs
@@ -66,6 +66,14 @@ pub struct FeeEvent {
 }
 
 #[derive(Debug, Copy, Clone, BorshDeserialize, BorshSerialize)]
+pub struct TimeInForceEvent {
+    pub index: u16,
+    pub order_sequence_number: u64,
+    pub last_valid_slot: u64,
+    pub last_valid_unix_timestamp_in_seconds: u64,
+}
+
+#[derive(Debug, Copy, Clone, BorshDeserialize, BorshSerialize)]
 pub enum PhoenixMarketEvent {
     Uninitialized,
     Header(AuditLogHeader),
@@ -75,6 +83,7 @@ pub enum PhoenixMarketEvent {
     Evict(EvictEvent),
     FillSummary(FillSummaryEvent),
     Fee(FeeEvent),
+    TimeInForce(TimeInForceEvent),
 }
 
 impl Default for PhoenixMarketEvent {
@@ -92,6 +101,7 @@ impl PhoenixMarketEvent {
             Self::FillSummary(FillSummaryEvent { index, .. }) => *index = i,
             Self::Evict(EvictEvent { index, .. }) => *index = i,
             Self::Fee(FeeEvent { index, .. }) => *index = i,
+            Self::TimeInForce(TimeInForceEvent { index, .. }) => *index = i,
             _ => panic!("Cannot set index on uninitialized or header event"),
         }
     }
@@ -166,6 +176,16 @@ impl From<MarketEvent<Pubkey>> for PhoenixMarketEvent {
                 fees_collected_in_quote_lots,
             } => Self::Fee(FeeEvent {
                 fees_collected_in_quote_lots: fees_collected_in_quote_lots.into(),
+                index: 0,
+            }),
+            MarketEvent::TimeInForce {
+                order_sequence_number,
+                last_valid_slot,
+                last_valid_unix_timestamp_in_seconds,
+            } => Self::TimeInForce(TimeInForceEvent {
+                order_sequence_number,
+                last_valid_slot,
+                last_valid_unix_timestamp_in_seconds,
                 index: 0,
             }),
         }

--- a/src/program/events.rs
+++ b/src/program/events.rs
@@ -74,7 +74,7 @@ pub struct TimeInForceEvent {
 }
 
 #[derive(Debug, Copy, Clone, BorshDeserialize, BorshSerialize)]
-pub struct ExpiredOrder {
+pub struct ExpiredOrderEvent {
     pub index: u16,
     pub maker_id: Pubkey,
     pub order_sequence_number: u64,
@@ -93,7 +93,7 @@ pub enum PhoenixMarketEvent {
     FillSummary(FillSummaryEvent),
     Fee(FeeEvent),
     TimeInForce(TimeInForceEvent),
-    ExpiredOrder(ExpiredOrder),
+    ExpiredOrder(ExpiredOrderEvent),
 }
 
 impl Default for PhoenixMarketEvent {
@@ -112,7 +112,7 @@ impl PhoenixMarketEvent {
             Self::Evict(EvictEvent { index, .. }) => *index = i,
             Self::Fee(FeeEvent { index, .. }) => *index = i,
             Self::TimeInForce(TimeInForceEvent { index, .. }) => *index = i,
-            Self::ExpiredOrder(ExpiredOrder { index, .. }) => *index = i,
+            Self::ExpiredOrder(ExpiredOrderEvent { index, .. }) => *index = i,
             _ => panic!("Cannot set index on uninitialized or header event"),
         }
     }
@@ -204,7 +204,7 @@ impl From<MarketEvent<Pubkey>> for PhoenixMarketEvent {
                 order_sequence_number,
                 price_in_ticks,
                 base_lots_removed,
-            } => Self::ExpiredOrder(ExpiredOrder {
+            } => Self::ExpiredOrder(ExpiredOrderEvent {
                 maker_id,
                 order_sequence_number,
                 price_in_ticks: price_in_ticks.into(),

--- a/src/program/processor/new_order.rs
+++ b/src/program/processor/new_order.rs
@@ -485,6 +485,12 @@ fn process_multiple_new_orders<'a, 'info>(
                     &quote_vault,
                     trader.as_ref(),
                 )?;
+            } else {
+                assert_with_msg(
+                    quote_lots_to_deposit == QuoteLots::ZERO,
+                    PhoenixError::CancelMultipleOrdersError,
+                    "Expected quote_lots_to_deposit to be zero",
+                )?;
             }
             if !asks.is_empty() {
                 maybe_invoke_deposit(
@@ -493,6 +499,12 @@ fn process_multiple_new_orders<'a, 'info>(
                     &base_account,
                     &base_vault,
                     trader.as_ref(),
+                )?;
+            } else {
+                assert_with_msg(
+                    base_lots_to_deposit == BaseLots::ZERO,
+                    PhoenixError::CancelMultipleOrdersError,
+                    "Expected base_lots_to_deposit to be zero",
                 )?;
             }
         }

--- a/src/state/inflight_order.rs
+++ b/src/state/inflight_order.rs
@@ -32,6 +32,10 @@ pub(crate) struct InflightOrder {
 
     /// Number of quote lots paid in fees
     pub quote_lot_fees: QuoteLots,
+
+    pub last_valid_slot: u64,
+
+    pub last_valid_unix_timestamp_in_seconds: u64,
 }
 
 impl InflightOrder {
@@ -42,6 +46,8 @@ impl InflightOrder {
         match_limit: u64,
         base_lot_budget: BaseLots,
         adjusted_quote_lot_budget: AdjustedQuoteLots,
+        last_valid_slot: u64,
+        last_valid_unix_timestamp_in_seconds: u64,
     ) -> Self {
         InflightOrder {
             side,
@@ -54,6 +60,8 @@ impl InflightOrder {
             matched_adjusted_quote_lots: AdjustedQuoteLots::ZERO,
             matched_base_lots: BaseLots::ZERO,
             quote_lot_fees: QuoteLots::ZERO,
+            last_valid_slot,
+            last_valid_unix_timestamp_in_seconds,
         }
     }
 

--- a/src/state/inflight_order.rs
+++ b/src/state/inflight_order.rs
@@ -33,9 +33,9 @@ pub(crate) struct InflightOrder {
     /// Number of quote lots paid in fees
     pub quote_lot_fees: QuoteLots,
 
-    pub last_valid_slot: u64,
+    pub last_valid_slot: Option<u64>,
 
-    pub last_valid_unix_timestamp_in_seconds: u64,
+    pub last_valid_unix_timestamp_in_seconds: Option<u64>,
 }
 
 impl InflightOrder {
@@ -46,8 +46,8 @@ impl InflightOrder {
         match_limit: u64,
         base_lot_budget: BaseLots,
         adjusted_quote_lot_budget: AdjustedQuoteLots,
-        last_valid_slot: u64,
-        last_valid_unix_timestamp_in_seconds: u64,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     ) -> Self {
         InflightOrder {
             side,

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -1079,6 +1079,18 @@ impl<
                     client_order_id: order_packet.client_order_id(),
                 });
 
+                if resting_order.last_valid_slot != 0
+                    || resting_order.last_valid_unix_timestamp_in_seconds != 0
+                {
+                    // Record the cancel event
+                    record_event_fn(MarketEvent::<MarketTraderId>::TimeInForce {
+                        order_sequence_number: order_id.order_sequence_number,
+                        last_valid_slot: resting_order.last_valid_slot,
+                        last_valid_unix_timestamp_in_seconds: resting_order
+                            .last_valid_unix_timestamp_in_seconds,
+                    });
+                }
+
                 // Increment the order sequence number after successfully placing an order
                 self.order_sequence_number += 1;
             }

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -1482,7 +1482,7 @@ impl<
         order_id: &FIFOOrderId,
         side: Side,
         size: Option<BaseLots>,
-        force_cancelled_or_expired: bool,
+        order_is_expired: bool,
         claim_funds: bool,
         record_event_fn: &mut dyn FnMut(MarketEvent<MarketTraderId>),
     ) -> Option<MatchingEngineResponse> {
@@ -1516,7 +1516,7 @@ impl<
                 resting_order.num_base_lots
             };
             // If the order was not cancelled by the maker, we make sure that the maker's id is logged.
-            if force_cancelled_or_expired {
+            if order_is_expired {
                 record_event_fn(MarketEvent::ExpiredOrder {
                     maker_id,
                     order_sequence_number: order_id.order_sequence_number,

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -1143,11 +1143,12 @@ impl<
                 )
             };
 
+            // This block is entered if the order has expired. The order is removed from the book and
+            // the match limit is decremented.
             if (last_valid_slot != 0 && last_valid_slot < current_slot)
                 || (last_valid_unix_timestamp_in_seconds != 0
                     && last_valid_unix_timestamp_in_seconds < current_unix_timestamp)
             {
-                // This block is entered if the order has expired
                 self.reduce_order_inner(
                     trader_index as u32,
                     &order_id,

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -1082,7 +1082,7 @@ impl<
                 if resting_order.last_valid_slot != 0
                     || resting_order.last_valid_unix_timestamp_in_seconds != 0
                 {
-                    // Record the cancel event
+                    // Record the time in force event
                     record_event_fn(MarketEvent::<MarketTraderId>::TimeInForce {
                         order_sequence_number: order_id.order_sequence_number,
                         last_valid_slot: resting_order.last_valid_slot,

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -780,8 +780,10 @@ impl<
                 FIFORestingOrder::new(
                     trader_index as u64,
                     order_packet.num_base_lots(),
-                    order_packet.get_last_valid_slot(),
-                    order_packet.get_last_valid_unix_timestamp_in_seconds(),
+                    order_packet.get_last_valid_slot().unwrap_or(0),
+                    order_packet
+                        .get_last_valid_unix_timestamp_in_seconds()
+                        .unwrap_or(0),
                 ),
                 MatchingEngineResponse::default(),
             )
@@ -806,8 +808,10 @@ impl<
                 order_packet.match_limit(),
                 base_lot_budget,
                 adjusted_quote_lot_budget,
-                order_packet.get_last_valid_slot(),
-                order_packet.get_last_valid_unix_timestamp_in_seconds(),
+                order_packet.get_last_valid_slot().unwrap_or(0),
+                order_packet
+                    .get_last_valid_unix_timestamp_in_seconds()
+                    .unwrap_or(0),
             );
             let resting_order = self
                 .match_order(

--- a/src/state/markets/market_events.rs
+++ b/src/state/markets/market_events.rs
@@ -38,4 +38,9 @@ pub enum MarketEvent<MarketTraderId: BorshDeserialize + BorshDeserialize> {
     Fee {
         fees_collected_in_quote_lots: QuoteLots,
     },
+    TimeInForce {
+        order_sequence_number: u64,
+        last_valid_slot: u64,
+        last_valid_unix_timestamp_in_seconds: u64,
+    },
 }

--- a/src/state/markets/market_events.rs
+++ b/src/state/markets/market_events.rs
@@ -43,4 +43,10 @@ pub enum MarketEvent<MarketTraderId: BorshDeserialize + BorshDeserialize> {
         last_valid_slot: u64,
         last_valid_unix_timestamp_in_seconds: u64,
     },
+    ExpiredOrder {
+        maker_id: MarketTraderId,
+        order_sequence_number: u64,
+        price_in_ticks: Ticks,
+        base_lots_removed: BaseLots,
+    },
 }

--- a/src/state/markets/market_traits.rs
+++ b/src/state/markets/market_traits.rs
@@ -175,6 +175,7 @@ pub(crate) trait WritableMarket<
         trader: &MarketTraderId,
         order_packet: MarketOrderPacket,
         record_event_fn: &mut dyn FnMut(MarketEvent<MarketTraderId>),
+        get_clock_fn: &mut dyn FnMut() -> (u64, u64),
     ) -> Option<(Option<MarketOrderId>, MatchingEngineResponse)>;
 
     fn cancel_order(

--- a/src/state/markets/test_market.rs
+++ b/src/state/markets/test_market.rs
@@ -2195,20 +2195,20 @@ fn test_tif() {
                     assert!(matches!(event, MarketEvent::FillSummary { .. }));
                 }
                 6 => {
-                    if let MarketEvent::Reduce {
+                    if let MarketEvent::ExpiredOrder {
+                        maker_id,
                         order_sequence_number,
                         price_in_ticks,
                         base_lots_removed,
-                        base_lots_remaining,
                     } = event
                     {
+                        assert_eq!(maker_id, &maker);
                         assert_eq!(
                             Side::from_order_sequence_number(*order_sequence_number),
                             Side::Bid
                         );
                         assert_eq!(*price_in_ticks, Ticks::new(1000));
                         assert_eq!(*base_lots_removed, BaseLots::new(80));
-                        assert_eq!(*base_lots_remaining, BaseLots::new(0));
                     } else {
                         panic!("Invalid event")
                     }

--- a/src/state/markets/test_market.rs
+++ b/src/state/markets/test_market.rs
@@ -2185,13 +2185,16 @@ fn test_tif() {
                 0 => {
                     assert!(matches!(event, MarketEvent::Place { .. }));
                 }
-                1 | 3 => {
+                1 => {
+                    assert!(matches!(event, MarketEvent::TimeInForce { .. }));
+                }
+                2 | 4 => {
                     assert!(matches!(event, MarketEvent::Fill { .. }));
                 }
-                2 | 4 | 6 => {
+                3 | 5 | 7 => {
                     assert!(matches!(event, MarketEvent::FillSummary { .. }));
                 }
-                5 => {
+                6 => {
                     if let MarketEvent::Reduce {
                         order_sequence_number,
                         price_in_ticks,

--- a/src/state/markets/test_market.rs
+++ b/src/state/markets/test_market.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::quantities::*;
 use crate::state::markets::*;
@@ -31,6 +32,13 @@ fn setup_market_with_params(
     );
     dex.set_fee(fees);
     *dex
+}
+
+fn get_clock_fn() -> (u64, u64) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    (now.as_millis() as u64, now.as_secs())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -78,6 +86,7 @@ fn layer_orders(
             &trader,
             OrderPacket::new_limit_order_default(side, *p, *s * adj),
             event_recorder,
+            &mut get_clock_fn,
         )
         .unwrap();
     }
@@ -165,6 +174,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -204,6 +214,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     println!(
@@ -232,6 +243,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
 
@@ -274,6 +286,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
 
@@ -379,6 +392,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 100, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     // Cannot place post only order that would match
@@ -387,6 +401,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Ask, 100, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -395,6 +410,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Ask, 102, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -402,6 +418,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 101, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -411,6 +428,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 102, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -436,6 +454,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 100, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     // Cannot place post only order that would match if reject flag is true
@@ -444,6 +463,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 100, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -452,6 +472,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 102, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -459,6 +480,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 101, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -468,6 +490,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 102, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -477,6 +500,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 100, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -486,6 +510,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 102, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -505,6 +530,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 1, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -514,6 +540,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 1, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -523,6 +550,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 0, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -546,6 +574,7 @@ fn test_cancel_all() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 1),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -557,6 +586,7 @@ fn test_cancel_all() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 102 + i, 1),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -580,6 +610,7 @@ fn test_limit_orders_with_self_trade() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 5),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     let ladder = market.get_typed_ladder(1);
@@ -591,6 +622,7 @@ fn test_limit_orders_with_self_trade() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     let mut res = MatchingEngineResponse::default();
@@ -613,6 +645,7 @@ fn test_limit_orders_with_self_trade() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
     let (order, matching_engine_response) = market
@@ -628,6 +661,7 @@ fn test_limit_orders_with_self_trade() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -657,6 +691,7 @@ fn test_limit_orders_with_self_trade() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -690,6 +725,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 5),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -698,6 +734,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 95, 15),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -706,6 +743,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Ask, 95, 15,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -715,6 +753,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 5),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -729,6 +768,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 20),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -744,6 +784,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -753,6 +794,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Bid, 101, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     let (order, matching_engine_response) = market
@@ -760,6 +802,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 50),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -777,6 +820,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Bid, 105, 55,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -786,6 +830,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 20),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -807,6 +852,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 50),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -828,6 +874,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 120, 50),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -835,6 +882,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 120, 25),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -844,6 +892,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Ask, 110, 25),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     let (order, matching_engine_response) = market
@@ -851,6 +900,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 111, 75),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -888,6 +938,7 @@ fn test_orders_with_only_free_funds() {
             &taker,
             OrderPacket::new_post_only(Side::Bid, 100, 5, 0, false, true,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -896,6 +947,7 @@ fn test_orders_with_only_free_funds() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 100, 5, 0, false, false,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -913,6 +965,7 @@ fn test_orders_with_only_free_funds() {
                 true,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -929,6 +982,7 @@ fn test_orders_with_only_free_funds() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -946,6 +1000,7 @@ fn test_orders_with_only_free_funds() {
                 true,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -962,6 +1017,7 @@ fn test_orders_with_only_free_funds() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -978,6 +1034,7 @@ fn test_orders_with_only_free_funds() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -995,6 +1052,7 @@ fn test_orders_with_only_free_funds() {
                 true,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 }
@@ -1010,6 +1068,7 @@ fn seed_market_with_orders(
                 trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10),
                 record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1017,6 +1076,7 @@ fn seed_market_with_orders(
                 trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10),
                 record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1051,6 +1111,7 @@ fn test_fok_and_ioc_limit_1() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_none());
@@ -1076,6 +1137,7 @@ fn test_fok_and_ioc_limit_1() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_none());
@@ -1110,6 +1172,7 @@ fn test_fok_and_ioc_limit_2() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
     assert!(market
@@ -1124,6 +1187,7 @@ fn test_fok_and_ioc_limit_2() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 }
@@ -1158,6 +1222,7 @@ fn test_fok_and_ioc_limit_3() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1181,6 +1246,7 @@ fn test_fok_and_ioc_limit_3() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1223,6 +1289,7 @@ fn test_fok_and_ioc_limit_4() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1252,6 +1319,7 @@ fn test_fok_and_ioc_limit_4() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1294,6 +1362,7 @@ fn test_fok_and_ioc_limit_5() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
     assert!(market
@@ -1308,6 +1377,7 @@ fn test_fok_and_ioc_limit_5() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -1328,6 +1398,7 @@ fn test_fok_and_ioc_limit_5() {
                     false,
                 ),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_none(),
         "Only one of num_base_lots or num_quote_lots should be set"
@@ -1381,6 +1452,7 @@ fn test_fok_with_slippage_1() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1388,6 +1460,7 @@ fn test_fok_with_slippage_1() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1424,6 +1497,7 @@ fn test_fok_with_slippage_1() {
                 min_base_lots_out.as_u64(),
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     println!("matching_engine_response: {:?}", matching_engine_response);
@@ -1483,6 +1557,7 @@ fn test_fok_with_slippage_2() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1490,6 +1565,7 @@ fn test_fok_with_slippage_2() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1507,6 +1583,7 @@ fn test_fok_with_slippage_2() {
                     .as_u64()
             ), // 2 full levels, 1 partial level
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 }
@@ -1529,6 +1606,7 @@ fn test_fok_with_slippage_3() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1536,6 +1614,7 @@ fn test_fok_with_slippage_3() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1573,6 +1652,7 @@ fn test_fok_with_slippage_3() {
                 min_quote_lots_out.as_u64(),
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_none());
@@ -1636,6 +1716,7 @@ fn test_fees_basic() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 9900, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -1643,6 +1724,7 @@ fn test_fees_basic() {
             &trader,
             OrderPacket::new_post_only_default(Side::Ask, 10100, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -1659,6 +1741,7 @@ fn test_fees_basic() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o_id.is_none());
@@ -1685,6 +1768,7 @@ fn test_fees_basic() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o_id.is_none());
@@ -1720,6 +1804,7 @@ fn test_evict_order() {
                 &trader,
                 OrderPacket::new_post_only_default(side, price.as_u64(), 1),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             );
         }
         let direction = match side {
@@ -1731,6 +1816,7 @@ fn test_evict_order() {
             &stink_order,
             OrderPacket::new_post_only_default(side, stink_price.as_u64(), 99),
             &mut record_event_fn,
+            &mut get_clock_fn,
         );
         // Order must be more aggressive than the least aggressive order in a full book
         assert!(market
@@ -1738,6 +1824,7 @@ fn test_evict_order() {
                 &stink_order,
                 OrderPacket::new_post_only_default(side, stink_price.as_u64(), 99),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_none());
         let mut event_recorder = VecDeque::new();
@@ -1751,6 +1838,7 @@ fn test_evict_order() {
                     99
                 ),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
 
@@ -1801,7 +1889,12 @@ fn test_reduce_order() {
     {
         let mut record_event_fn = |e: MarketEvent<TraderId>| event_recorder.push_back(e);
         market
-            .place_order(&maker, order_packet, &mut record_event_fn)
+            .place_order(
+                &maker,
+                order_packet,
+                &mut record_event_fn,
+                &mut get_clock_fn,
+            )
             .unwrap();
     }
 
@@ -1857,7 +1950,12 @@ fn test_reduce_order() {
     {
         let mut record_event_fn = |e: MarketEvent<TraderId>| event_recorder.push_back(e);
         market
-            .place_order(&random_maker, order_packet, &mut record_event_fn)
+            .place_order(
+                &random_maker,
+                order_packet,
+                &mut record_event_fn,
+                &mut get_clock_fn,
+            )
             .unwrap();
         assert!(
             market

--- a/src/state/order_schema/order_packet.rs
+++ b/src/state/order_schema/order_packet.rs
@@ -598,16 +598,17 @@ impl OrderPacket {
     }
 
     pub fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool {
-        let last_valid_slot = self.get_last_valid_slot().unwrap_or(0);
-        let last_valid_unix_timestamp_in_seconds =
-            self.get_last_valid_unix_timestamp_in_seconds().unwrap_or(0);
-        if last_valid_slot != 0 && current_slot > last_valid_slot {
-            return true;
+        if let Some(last_valid_slot) = self.get_last_valid_slot() {
+            if current_slot > last_valid_slot {
+                return true;
+            }
         }
-        if last_valid_unix_timestamp_in_seconds != 0
-            && current_unix_timestamp_in_seconds > last_valid_unix_timestamp_in_seconds
+        if let Some(last_valid_unix_timestamp_in_seconds) =
+            self.get_last_valid_unix_timestamp_in_seconds()
         {
-            return true;
+            if current_unix_timestamp_in_seconds > last_valid_unix_timestamp_in_seconds {
+                return true;
+            }
         }
         false
     }

--- a/src/state/order_schema/order_packet.rs
+++ b/src/state/order_schema/order_packet.rs
@@ -571,35 +571,36 @@ impl OrderPacket {
         }
     }
 
-    pub fn get_last_valid_slot(&self) -> u64 {
+    pub fn get_last_valid_slot(&self) -> Option<u64> {
         match self {
             Self::PostOnly {
                 last_valid_slot, ..
-            } => last_valid_slot.unwrap_or(0),
+            } => *last_valid_slot,
             Self::Limit {
                 last_valid_slot, ..
-            } => last_valid_slot.unwrap_or(0),
-            Self::ImmediateOrCancel { .. } => 0,
+            } => *last_valid_slot,
+            Self::ImmediateOrCancel { .. } => None,
         }
     }
 
-    pub fn get_last_valid_unix_timestamp_in_seconds(&self) -> u64 {
+    pub fn get_last_valid_unix_timestamp_in_seconds(&self) -> Option<u64> {
         match self {
             Self::PostOnly {
                 last_valid_unix_timestamp_in_seconds,
                 ..
-            } => last_valid_unix_timestamp_in_seconds.unwrap_or(0),
+            } => *last_valid_unix_timestamp_in_seconds,
             Self::Limit {
                 last_valid_unix_timestamp_in_seconds,
                 ..
-            } => last_valid_unix_timestamp_in_seconds.unwrap_or(0),
-            Self::ImmediateOrCancel { .. } => 0,
+            } => *last_valid_unix_timestamp_in_seconds,
+            Self::ImmediateOrCancel { .. } => None,
         }
     }
 
     pub fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool {
-        let last_valid_slot = self.get_last_valid_slot();
-        let last_valid_unix_timestamp_in_seconds = self.get_last_valid_unix_timestamp_in_seconds();
+        let last_valid_slot = self.get_last_valid_slot().unwrap_or(0);
+        let last_valid_unix_timestamp_in_seconds =
+            self.get_last_valid_unix_timestamp_in_seconds().unwrap_or(0);
         if last_valid_slot != 0 && current_slot > last_valid_slot {
             return true;
         }

--- a/tests/test_phoenix.rs
+++ b/tests/test_phoenix.rs
@@ -3,6 +3,7 @@ use ellipsis_client::EllipsisClient;
 use phoenix::phoenix_log_authority;
 use phoenix::program::deposit::DepositParams;
 use phoenix::program::instruction_builders::*;
+use phoenix::program::new_order::CondensedOrder;
 use phoenix::program::new_order::MultipleOrderPacket;
 use phoenix::program::MarketHeader;
 use phoenix::quantities::WrapperU64;
@@ -2280,24 +2281,32 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Place multiple post only orders successfully
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
-                sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(9.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(8.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(9.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
         vec![
-            (
-                sdk.float_price_to_ticks(10.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(11.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(10.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(11.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
     );
 
@@ -2332,25 +2341,25 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure free funds order doesnt place if not enough base lots but enough quote lots
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
+                sdk.raw_base_units_to_base_lots(9.0),
             ),
-            (
-                sdk.float_price_to_ticks(9.0),
+            CondensedOrder::new_default(
+                sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(10.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(12.0),
                 sdk.raw_base_units_to_base_lots(4.0),
             ),
@@ -2373,28 +2382,38 @@ async fn test_phoenix_place_multiple_limit_orders() {
 
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
-                sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(9.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(3.0),
-                sdk.raw_base_units_to_base_lots(1.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(8.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(9.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(3.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(1.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
         vec![
-            (
-                sdk.float_price_to_ticks(10.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(11.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(10.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(11.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
     );
 
@@ -2413,28 +2432,38 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // place multiple post only orders successfully with free funds
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
-                sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(9.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(8.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(9.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
         vec![
-            (
-                sdk.float_price_to_ticks(17.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(17.0),
-                sdk.raw_base_units_to_base_lots(5.0),
-            ),
-            (
-                sdk.float_price_to_ticks(12.0),
-                sdk.raw_base_units_to_base_lots(5.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(17.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(17.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(5.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(12.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(5.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
     );
     let new_order_ix = create_new_multiple_order_with_free_funds_instruction(
@@ -2474,21 +2503,21 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure we can't place orders in cross against themselves
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(8.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2512,25 +2541,25 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure we can't place orders in cross against themselves, different variation
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(29.0),
                 sdk.raw_base_units_to_base_lots(1.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(19.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(30.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(25.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2589,21 +2618,21 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure we can't place orders in cross against the existing book
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(8.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(10.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2626,11 +2655,11 @@ async fn test_phoenix_place_multiple_limit_orders() {
 
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(20.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2656,46 +2685,46 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Currently have 20 base units and 170 quote units available
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(5.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(4.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(3.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(5.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 //this order is all of the extra quote lots we need to deposit
                 sdk.float_price_to_ticks(4.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(105.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(103.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 //this order is all of the extra base lots we need to deposit
                 sdk.float_price_to_ticks(102.0),
                 sdk.raw_base_units_to_base_lots(5.0),
@@ -2751,7 +2780,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Send 100 orders on each side to verify there is enough compute to do so
     let bids = (1..101)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2759,7 +2788,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
         .collect::<Vec<_>>();
     let asks = (1..101)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2790,7 +2819,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
     //Send multiple orders in cross via the second maker - verify this throws an error
     let bids = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(101.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2798,7 +2827,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
         .collect::<Vec<_>>();
     let asks = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(99.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2822,7 +2851,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Send multiple orders in cross via the second maker, this time with post only rejection set to false - verify this succeeds
     let bids = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(101.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2830,7 +2859,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
         .collect::<Vec<_>>();
     let asks = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(99.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -3015,7 +3044,7 @@ async fn test_phoenix_place_multiple_memory_management() {
     // Send 40 orders on each side to verify there is enough compute to do so
     let bids = (1..41)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(1.0),
             )
@@ -3023,7 +3052,7 @@ async fn test_phoenix_place_multiple_memory_management() {
         .collect::<Vec<_>>();
     let asks = (1..41)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(1.0),
             )
@@ -3098,10 +3127,10 @@ async fn test_phoenix_place_multiple_limit_orders_adversarial() {
     // Stuff the book with 1 lots
     loop {
         let bids = (start..start + 30)
-            .map(|_| (sdk.float_price_to_ticks(99.0), 1))
+            .map(|_| CondensedOrder::new_default(sdk.float_price_to_ticks(99.0), 1))
             .collect::<Vec<_>>();
         let asks = (start..start + 30)
-            .map(|_| (sdk.float_price_to_ticks(100.0), 1))
+            .map(|_| CondensedOrder::new_default(sdk.float_price_to_ticks(100.0), 1))
             .collect::<Vec<_>>();
 
         let multiple_order_packet = MultipleOrderPacket::new_default(bids, asks);


### PR DESCRIPTION
Draft implementation of time-in-force (TIF) orders for Phoenix v1.

Added a standard test in test_market.rs. Could use more coverage

Changes:
- Uses the padding on the FIFORestingOrder to store and expiration slot and an expiration time
- Modifies the OrderPacket struct to enable specification of expiration
- Injects logic into the matching engine to skip orders that are expired