### PR TITLE
Add minor changes to matching engine logic

### DIFF
--- a/idl/generateClient.js
+++ b/idl/generateClient.js
@@ -1,4 +1,5 @@
 const { Solita } = require("@metaplex-foundation/solita");
+const { spawn } = require("child_process");
 
 const path = require("path");
 const idlDir = __dirname;
@@ -8,7 +9,16 @@ const PROGRAM_NAME = "phoenix_v1";
 
 async function main() {
   generateTypeScriptSDK().then(() => {
-    conoole.log("done");
+    console.log("Running prettier on generated files...");
+    spawn("prettier", ["--write", sdkDir], { stdio: "inherit" })
+      .on("error", (err) => {
+        console.error(
+          "Failed to lint client files. Try installing prettier (`npm install --save-dev --save-exact prettier`)"
+        );
+      })
+      .on("exit", () => {
+        console.log("Finished linting files.");
+      });
   });
 }
 
@@ -18,8 +28,6 @@ async function generateTypeScriptSDK() {
   const idl = require(generatedIdlPath);
   const gen = new Solita(idl, { formatCode: true });
   await gen.renderAndWriteTo(sdkDir);
-  console.error("Success!");
-  process.exit(0);
 }
 
 main().catch((err) => {

--- a/idl/generateClient.js
+++ b/idl/generateClient.js
@@ -10,6 +10,8 @@ const PROGRAM_NAME = "phoenix_v1";
 async function main() {
   generateTypeScriptSDK().then(() => {
     console.log("Running prettier on generated files...");
+    // Note: prettier is not a dependency of this package, so it must be installed
+    // TODO: Add a prettier config file for consistent style
     spawn("prettier", ["--write", sdkDir], { stdio: "inherit" })
       .on("error", (err) => {
         console.error(

--- a/idl/phoenix_v1.json
+++ b/idl/phoenix_v1.json
@@ -2316,6 +2316,18 @@
               {
                 "name": "use_only_deposited_funds",
                 "type": "bool"
+              },
+              {
+                "name": "last_valid_slot",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "last_valid_unix_timestamp_in_seconds",
+                "type": {
+                  "option": "u64"
+                }
               }
             ]
           },
@@ -2355,6 +2367,18 @@
               {
                 "name": "use_only_deposited_funds",
                 "type": "bool"
+              },
+              {
+                "name": "last_valid_slot",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "last_valid_unix_timestamp_in_seconds",
+                "type": {
+                  "option": "u64"
+                }
               }
             ]
           },

--- a/src/program/processor/withdraw.rs
+++ b/src/program/processor/withdraw.rs
@@ -81,7 +81,7 @@ pub(crate) fn process_withdraw<'a, 'info>(
                 base_lots_to_withdraw.map(BaseLots::new),
                 evict_seat,
             )
-            .ok_or(PhoenixError::ReduceOrderError)?;
+            .ok_or(PhoenixError::WithdrawFundsError)?;
         sol_log_compute_units();
         if evict_seat {
             assert_with_msg(

--- a/src/shank_structs.rs
+++ b/src/shank_structs.rs
@@ -40,6 +40,8 @@ enum OrderPacket {
         client_order_id: u128,
         reject_post_only: bool,
         use_only_deposited_funds: bool,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     },
     Limit {
         side: Side,
@@ -49,6 +51,8 @@ enum OrderPacket {
         match_limit: Option<u64>,
         client_order_id: u128,
         use_only_deposited_funds: bool,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     },
     ImmediateOrCancel {
         side: Side,

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -1102,8 +1102,14 @@ impl<
                 }
 
                 // Check if trader has enough deposited funds to process the order
-                if !matching_engine_response.verify_no_deposit_or_withdrawal() {
-                    phoenix_log!("Insufficient deposited funds to process order");
+                if !matching_engine_response.verify_no_deposit() {
+                    phoenix_log!("Trader does not have enough deposited funds to process order");
+                    return None;
+                }
+
+                // Check that the matching engine response does not withdraw any base or quote lots
+                if !matching_engine_response.verify_no_withdrawal() {
+                    phoenix_log!("Matching engine response withdraws base or quote lots");
                     return None;
                 }
             }

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -775,6 +775,11 @@ impl<
             self.get_or_register_trader(trader_id)?
         };
 
+        if order_packet.num_base_lots() == 0 && order_packet.num_quote_lots() == 0 {
+            phoenix_log!("Either num_base_lots or num_quote_lots must be nonzero");
+            return None;
+        }
+
         // For IOC order types exactly one of num_quote_lots or num_base_lots needs to be specified.
         if let OrderPacket::ImmediateOrCancel {
             num_base_lots,

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -156,17 +156,33 @@ impl FIFORestingOrder {
             last_valid_unix_timestamp_in_seconds,
         }
     }
-
-    pub fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool {
-        (self.last_valid_slot != 0 && self.last_valid_slot < current_slot)
-            || (self.last_valid_unix_timestamp_in_seconds != 0
-                && self.last_valid_unix_timestamp_in_seconds < current_unix_timestamp_in_seconds)
-    }
 }
 
 impl RestingOrder for FIFORestingOrder {
     fn size(&self) -> u64 {
         self.num_base_lots.as_u64()
+    }
+
+    fn last_valid_slot(&self) -> Option<u64> {
+        if self.last_valid_slot == 0 {
+            None
+        } else {
+            Some(self.last_valid_slot)
+        }
+    }
+
+    fn last_valid_unix_timestamp_in_seconds(&self) -> Option<u64> {
+        if self.last_valid_unix_timestamp_in_seconds == 0 {
+            None
+        } else {
+            Some(self.last_valid_unix_timestamp_in_seconds)
+        }
+    }
+
+    fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool {
+        (self.last_valid_slot != 0 && self.last_valid_slot < current_slot)
+            || (self.last_valid_unix_timestamp_in_seconds != 0
+                && self.last_valid_unix_timestamp_in_seconds < current_unix_timestamp_in_seconds)
     }
 }
 

--- a/src/state/markets/market_traits.rs
+++ b/src/state/markets/market_traits.rs
@@ -43,6 +43,9 @@ pub trait OrderId {
 
 pub trait RestingOrder {
     fn size(&self) -> u64;
+    fn last_valid_slot(&self) -> Option<u64>;
+    fn last_valid_unix_timestamp_in_seconds(&self) -> Option<u64>;
+    fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool;
 }
 
 /// A wrapper around an matching algorithm implementation that allows arbitrary structs to be
@@ -87,6 +90,18 @@ pub trait Market<
     }
 
     fn get_typed_ladder(&self, levels: u64) -> TypedLadder {
+        self.get_typed_ladder_with_expiration(levels, None, None)
+    }
+
+    fn get_typed_ladder_with_expiration(
+        &self,
+        levels: u64,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
+    ) -> TypedLadder {
+        let slot_expiration = last_valid_slot.unwrap_or_else(|| u64::MAX);
+        let unix_timestamp_expiration =
+            last_valid_unix_timestamp_in_seconds.unwrap_or_else(|| u64::MAX);
         let mut bids = vec![];
         let mut asks = vec![];
         for (side, book) in [(Side::Bid, &mut bids), (Side::Ask, &mut asks)].iter_mut() {
@@ -94,8 +109,12 @@ pub trait Market<
                 &self
                     .get_book(*side)
                     .iter()
-                    .map(|(order_id, resting_order)| {
-                        (order_id.price_in_ticks(), resting_order.size())
+                    .filter_map(|(order_id, resting_order)| {
+                        if resting_order.is_expired(slot_expiration, unix_timestamp_expiration) {
+                            None
+                        } else {
+                            Some((order_id.price_in_ticks(), resting_order.size()))
+                        }
                     })
                     .group_by(|(price_in_ticks, _)| *price_in_ticks)
                     .into_iter()

--- a/src/state/markets/market_traits.rs
+++ b/src/state/markets/market_traits.rs
@@ -99,9 +99,8 @@ pub trait Market<
         last_valid_slot: Option<u64>,
         last_valid_unix_timestamp_in_seconds: Option<u64>,
     ) -> TypedLadder {
-        let slot_expiration = last_valid_slot.unwrap_or_else(|| u64::MAX);
-        let unix_timestamp_expiration =
-            last_valid_unix_timestamp_in_seconds.unwrap_or_else(|| u64::MAX);
+        let slot_expiration = last_valid_slot.unwrap_or_else(|| 0);
+        let unix_timestamp_expiration = last_valid_unix_timestamp_in_seconds.unwrap_or_else(|| 0);
         let mut bids = vec![];
         let mut asks = vec![];
         for (side, book) in [(Side::Bid, &mut bids), (Side::Ask, &mut asks)].iter_mut() {

--- a/src/state/markets/market_traits.rs
+++ b/src/state/markets/market_traits.rs
@@ -68,7 +68,20 @@ pub trait Market<
     }
 
     fn get_ladder(&self, levels: u64) -> Ladder {
-        let ladder = self.get_typed_ladder(levels);
+        self.get_ladder_with_expiration(levels, None, None)
+    }
+
+    fn get_ladder_with_expiration(
+        &self,
+        levels: u64,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
+    ) -> Ladder {
+        let ladder = self.get_typed_ladder_with_expiration(
+            levels,
+            last_valid_slot,
+            last_valid_unix_timestamp_in_seconds,
+        );
         Ladder {
             bids: ladder
                 .bids

--- a/src/state/matching_engine_response.rs
+++ b/src/state/matching_engine_response.rs
@@ -94,8 +94,13 @@ impl MatchingEngineResponse {
     }
 
     #[inline(always)]
-    pub fn verify_no_deposit_or_withdrawal(&self) -> bool {
+    pub fn verify_no_deposit(&self) -> bool {
         self.num_base_lots_in + self.num_base_lots_posted == self.num_free_base_lots_used
             && self.num_quote_lots_in + self.num_quote_lots_posted == self.num_free_quote_lots_used
+    }
+
+    #[inline(always)]
+    pub fn verify_no_withdrawal(&self) -> bool {
+        self.num_base_lots_out == BaseLots::ZERO && self.num_quote_lots_out == QuoteLots::ZERO
     }
 }


### PR DESCRIPTION
Changes:
- DecrementTake handles partial removals
- Free fund accounting now occurs after the matching/order placement to ensure that checks work as intended.