### PR TITLE
Time In Force (#23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-v1"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "borsh 0.9.3",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-v1"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 resolver = "2"
 repository = "https://github.com/Ellipsis-Labs/phoenix-v1"

--- a/idl/generateClient.js
+++ b/idl/generateClient.js
@@ -1,4 +1,5 @@
 const { Solita } = require("@metaplex-foundation/solita");
+const { spawn } = require("child_process");
 
 const path = require("path");
 const idlDir = __dirname;
@@ -8,7 +9,18 @@ const PROGRAM_NAME = "phoenix_v1";
 
 async function main() {
   generateTypeScriptSDK().then(() => {
-    conoole.log("done");
+    console.log("Running prettier on generated files...");
+    // Note: prettier is not a dependency of this package, so it must be installed
+    // TODO: Add a prettier config file for consistent style
+    spawn("prettier", ["--write", sdkDir], { stdio: "inherit" })
+      .on("error", (err) => {
+        console.error(
+          "Failed to lint client files. Try installing prettier (`npm install --save-dev --save-exact prettier`)"
+        );
+      })
+      .on("exit", () => {
+        console.log("Finished linting files.");
+      });
   });
 }
 
@@ -18,8 +30,6 @@ async function generateTypeScriptSDK() {
   const idl = require(generatedIdlPath);
   const gen = new Solita(idl, { formatCode: true });
   await gen.renderAndWriteTo(sdkDir);
-  console.error("Success!");
-  process.exit(0);
 }
 
 main().catch((err) => {

--- a/idl/phoenix_v1.json
+++ b/idl/phoenix_v1.json
@@ -1801,6 +1801,58 @@
       }
     },
     {
+      "name": "TimeInForceEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "orderSequenceNumber",
+            "type": "u64"
+          },
+          {
+            "name": "lastValidSlot",
+            "type": "u64"
+          },
+          {
+            "name": "lastValidUnixTimestampInSeconds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExpiredOrderEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "makerId",
+            "type": "publicKey"
+          },
+          {
+            "name": "orderSequenceNumber",
+            "type": "u64"
+          },
+          {
+            "name": "priceInTicks",
+            "type": "u64"
+          },
+          {
+            "name": "baseLotsRemoved",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "CancelUpToParams",
       "type": {
         "kind": "struct",
@@ -1950,6 +2002,18 @@
           {
             "name": "sizeInBaseLots",
             "type": "u64"
+          },
+          {
+            "name": "lastValidSlot",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "lastValidUnixTimestampInSeconds",
+            "type": {
+              "option": "u64"
+            }
           }
         ]
       }
@@ -2154,6 +2218,22 @@
             "fields": [
               {
                 "defined": "FeeEvent"
+              }
+            ]
+          },
+          {
+            "name": "TimeInForce",
+            "fields": [
+              {
+                "defined": "TimeInForceEvent"
+              }
+            ]
+          },
+          {
+            "name": "ExpiredOrder",
+            "fields": [
+              {
+                "defined": "ExpiredOrderEvent"
               }
             ]
           }

--- a/idl/phoenix_v1.json
+++ b/idl/phoenix_v1.json
@@ -2316,6 +2316,18 @@
               {
                 "name": "use_only_deposited_funds",
                 "type": "bool"
+              },
+              {
+                "name": "last_valid_slot",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "last_valid_unix_timestamp_in_seconds",
+                "type": {
+                  "option": "u64"
+                }
               }
             ]
           },
@@ -2355,6 +2367,18 @@
               {
                 "name": "use_only_deposited_funds",
                 "type": "bool"
+              },
+              {
+                "name": "last_valid_slot",
+                "type": {
+                  "option": "u64"
+                }
+              },
+              {
+                "name": "last_valid_unix_timestamp_in_seconds",
+                "type": {
+                  "option": "u64"
+                }
               }
             ]
           },

--- a/src/program/processor/new_order.rs
+++ b/src/program/processor/new_order.rs
@@ -7,14 +7,14 @@ use crate::{
         token_utils::{maybe_invoke_deposit, maybe_invoke_withdraw},
         MarketHeader, PhoenixMarketContext, PhoenixVaultContext,
     },
-    quantities::{BaseAtoms, BaseLots, QuoteAtoms, QuoteLots, WrapperU64},
+    quantities::{BaseAtoms, BaseLots, QuoteAtoms, QuoteLots, Ticks, WrapperU64},
     state::{markets::MarketEvent, OrderPacket, OrderPacketMetadata, Side},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, log::sol_log_compute_units,
-    program_error::ProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult, log::sol_log_compute_units,
+    program_error::ProgramError, pubkey::Pubkey, sysvar::Sysvar,
 };
 use std::mem::size_of;
 
@@ -32,51 +32,40 @@ pub struct MultipleOrderPacket {
 pub struct CondensedOrder {
     pub price_in_ticks: u64,
     pub size_in_base_lots: u64,
+    pub last_valid_slot: Option<u64>,
+    pub last_valid_unix_timestamp_in_seconds: Option<u64>,
+}
+
+impl CondensedOrder {
+    pub fn new_default(price_in_ticks: u64, size_in_base_lots: u64) -> Self {
+        CondensedOrder {
+            price_in_ticks,
+            size_in_base_lots,
+            last_valid_slot: None,
+            last_valid_unix_timestamp_in_seconds: None,
+        }
+    }
 }
 
 impl MultipleOrderPacket {
     pub fn new(
-        bids: Vec<(u64, u64)>,
-        asks: Vec<(u64, u64)>,
+        bids: Vec<CondensedOrder>,
+        asks: Vec<CondensedOrder>,
         client_order_id: Option<u128>,
         reject_post_only: bool,
     ) -> Self {
         MultipleOrderPacket {
-            bids: bids
-                .iter()
-                .map(|(p, s)| CondensedOrder {
-                    price_in_ticks: *p,
-                    size_in_base_lots: *s,
-                })
-                .collect(),
-            asks: asks
-                .iter()
-                .map(|(p, s)| CondensedOrder {
-                    price_in_ticks: *p,
-                    size_in_base_lots: *s,
-                })
-                .collect(),
+            bids,
+            asks,
             client_order_id,
             reject_post_only,
         }
     }
 
-    pub fn new_default(bids: Vec<(u64, u64)>, asks: Vec<(u64, u64)>) -> Self {
+    pub fn new_default(bids: Vec<CondensedOrder>, asks: Vec<CondensedOrder>) -> Self {
         MultipleOrderPacket {
-            bids: bids
-                .iter()
-                .map(|(p, s)| CondensedOrder {
-                    price_in_ticks: *p,
-                    size_in_base_lots: *s,
-                })
-                .collect(),
-            asks: asks
-                .iter()
-                .map(|(p, s)| CondensedOrder {
-                    price_in_ticks: *p,
-                    size_in_base_lots: *s,
-                })
-                .collect(),
+            bids,
+            asks,
             client_order_id: None,
             reject_post_only: true,
         }
@@ -303,10 +292,17 @@ fn process_new_order<'a, 'info>(
         base_atoms_to_withdraw,
         base_atoms_to_deposit,
     ) = {
+        let clock = Clock::get()?;
+        let mut get_clock_fn = || (clock.slot, clock.unix_timestamp as u64);
         let market_bytes = &mut market_info.try_borrow_mut_data()?[size_of::<MarketHeader>()..];
         let market = load_with_dispatch_mut(&market_info.size_params, market_bytes)?.inner;
         let (_order_id, matching_engine_response) = market
-            .place_order(trader.key, *order_packet, record_event_fn)
+            .place_order(
+                trader.key,
+                *order_packet,
+                record_event_fn,
+                &mut get_clock_fn,
+            )
             .ok_or(PhoenixError::NewOrderError)?;
 
         (
@@ -413,33 +409,53 @@ fn process_multiple_new_orders<'a, 'info>(
     };
 
     {
+        let clock = Clock::get()?;
+        let mut get_clock_fn = || (clock.slot, clock.unix_timestamp as u64);
         let market_bytes = &mut market_info.try_borrow_mut_data()?[size_of::<MarketHeader>()..];
         let market = load_with_dispatch_mut(&market_info.size_params, market_bytes)?.inner;
         for (book_orders, side) in [(&bids, Side::Bid), (&asks, Side::Ask)].iter() {
             for CondensedOrder {
                 price_in_ticks,
                 size_in_base_lots,
+                last_valid_slot,
+                last_valid_unix_timestamp_in_seconds,
             } in book_orders
                 .iter()
                 .sorted_by(|o1, o2| o1.price_in_ticks.cmp(&o2.price_in_ticks))
-                .group_by(|o| o.price_in_ticks)
-                .into_iter()
-                .map(|(price_in_ticks, level)| CondensedOrder {
-                    price_in_ticks,
-                    size_in_base_lots: level.fold(0, |acc, o| acc + o.size_in_base_lots),
+                .group_by(|o| {
+                    (
+                        o.price_in_ticks,
+                        o.last_valid_slot,
+                        o.last_valid_unix_timestamp_in_seconds,
+                    )
                 })
+                .into_iter()
+                .map(
+                    |(
+                        (price_in_ticks, last_valid_slot, last_valid_unix_timestamp_in_seconds),
+                        level,
+                    )| CondensedOrder {
+                        price_in_ticks,
+                        size_in_base_lots: level.fold(0, |acc, o| acc + o.size_in_base_lots),
+                        last_valid_slot,
+                        last_valid_unix_timestamp_in_seconds,
+                    },
+                )
             {
-                let order_packet = OrderPacket::new_post_only(
-                    *side,
-                    price_in_ticks,
-                    size_in_base_lots,
+                let order_packet = OrderPacket::PostOnly {
+                    side: *side,
+                    price_in_ticks: Ticks::new(price_in_ticks),
+                    num_base_lots: BaseLots::new(size_in_base_lots),
                     client_order_id,
                     reject_post_only,
-                    no_deposit,
-                );
+                    use_only_deposited_funds: no_deposit,
+                    last_valid_slot,
+                    last_valid_unix_timestamp_in_seconds,
+                };
+
                 let matching_engine_response = {
                     let (_order_id, matching_engine_response) = market
-                        .place_order(trader.key, order_packet, record_event_fn)
+                        .place_order(trader.key, order_packet, record_event_fn, &mut get_clock_fn)
                         .ok_or(PhoenixError::NewOrderError)?;
                     matching_engine_response
                 };
@@ -469,6 +485,12 @@ fn process_multiple_new_orders<'a, 'info>(
                     &quote_vault,
                     trader.as_ref(),
                 )?;
+            } else {
+                assert_with_msg(
+                    quote_lots_to_deposit == QuoteLots::ZERO,
+                    PhoenixError::CancelMultipleOrdersError,
+                    "Expected quote_lots_to_deposit to be zero",
+                )?;
             }
             if !asks.is_empty() {
                 maybe_invoke_deposit(
@@ -477,6 +499,12 @@ fn process_multiple_new_orders<'a, 'info>(
                     &base_account,
                     &base_vault,
                     trader.as_ref(),
+                )?;
+            } else {
+                assert_with_msg(
+                    base_lots_to_deposit == BaseLots::ZERO,
+                    PhoenixError::CancelMultipleOrdersError,
+                    "Expected base_lots_to_deposit to be zero",
                 )?;
             }
         }

--- a/src/program/processor/withdraw.rs
+++ b/src/program/processor/withdraw.rs
@@ -81,7 +81,7 @@ pub(crate) fn process_withdraw<'a, 'info>(
                 base_lots_to_withdraw.map(BaseLots::new),
                 evict_seat,
             )
-            .ok_or(PhoenixError::ReduceOrderError)?;
+            .ok_or(PhoenixError::WithdrawFundsError)?;
         sol_log_compute_units();
         if evict_seat {
             assert_with_msg(

--- a/src/shank_structs.rs
+++ b/src/shank_structs.rs
@@ -40,6 +40,8 @@ enum OrderPacket {
         client_order_id: u128,
         reject_post_only: bool,
         use_only_deposited_funds: bool,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     },
     Limit {
         side: Side,
@@ -49,6 +51,8 @@ enum OrderPacket {
         match_limit: Option<u64>,
         client_order_id: u128,
         use_only_deposited_funds: bool,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     },
     ImmediateOrCancel {
         side: Side,

--- a/src/state/inflight_order.rs
+++ b/src/state/inflight_order.rs
@@ -32,6 +32,10 @@ pub(crate) struct InflightOrder {
 
     /// Number of quote lots paid in fees
     pub quote_lot_fees: QuoteLots,
+
+    pub last_valid_slot: Option<u64>,
+
+    pub last_valid_unix_timestamp_in_seconds: Option<u64>,
 }
 
 impl InflightOrder {
@@ -42,6 +46,8 @@ impl InflightOrder {
         match_limit: u64,
         base_lot_budget: BaseLots,
         adjusted_quote_lot_budget: AdjustedQuoteLots,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     ) -> Self {
         InflightOrder {
             side,
@@ -54,6 +60,8 @@ impl InflightOrder {
             matched_adjusted_quote_lots: AdjustedQuoteLots::ZERO,
             matched_base_lots: BaseLots::ZERO,
             quote_lot_fees: QuoteLots::ZERO,
+            last_valid_slot,
+            last_valid_unix_timestamp_in_seconds,
         }
     }
 

--- a/src/state/markets/fifo.rs
+++ b/src/state/markets/fifo.rs
@@ -156,17 +156,33 @@ impl FIFORestingOrder {
             last_valid_unix_timestamp_in_seconds,
         }
     }
-
-    pub fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool {
-        (self.last_valid_slot != 0 && self.last_valid_slot < current_slot)
-            || (self.last_valid_unix_timestamp_in_seconds != 0
-                && self.last_valid_unix_timestamp_in_seconds < current_unix_timestamp_in_seconds)
-    }
 }
 
 impl RestingOrder for FIFORestingOrder {
     fn size(&self) -> u64 {
         self.num_base_lots.as_u64()
+    }
+
+    fn last_valid_slot(&self) -> Option<u64> {
+        if self.last_valid_slot == 0 {
+            None
+        } else {
+            Some(self.last_valid_slot)
+        }
+    }
+
+    fn last_valid_unix_timestamp_in_seconds(&self) -> Option<u64> {
+        if self.last_valid_unix_timestamp_in_seconds == 0 {
+            None
+        } else {
+            Some(self.last_valid_unix_timestamp_in_seconds)
+        }
+    }
+
+    fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool {
+        (self.last_valid_slot != 0 && self.last_valid_slot < current_slot)
+            || (self.last_valid_unix_timestamp_in_seconds != 0
+                && self.last_valid_unix_timestamp_in_seconds < current_unix_timestamp_in_seconds)
     }
 }
 
@@ -775,6 +791,11 @@ impl<
             self.get_or_register_trader(trader_id)?
         };
 
+        if order_packet.num_base_lots() == 0 && order_packet.num_quote_lots() == 0 {
+            phoenix_log!("Either num_base_lots or num_quote_lots must be nonzero");
+            return None;
+        }
+
         // For IOC order types exactly one of num_quote_lots or num_base_lots needs to be specified.
         if let OrderPacket::ImmediateOrCancel {
             num_base_lots,
@@ -868,7 +889,7 @@ impl<
                     )
                 }),
             }
-            .unwrap_or(AdjustedQuoteLots::new(u64::MAX));
+            .unwrap_or_else(|| AdjustedQuoteLots::new(u64::MAX));
 
             let mut inflight_order = InflightOrder::new(
                 side,
@@ -912,7 +933,7 @@ impl<
                         - inflight_order.quote_lot_fees
                 }
             };
-            let mut matching_engine_response = match side {
+            let matching_engine_response = match side {
                 Side::Bid => MatchingEngineResponse::new_from_buy(
                     matched_quote_lots,
                     inflight_order.matched_base_lots,
@@ -922,44 +943,6 @@ impl<
                     matched_quote_lots,
                 ),
             };
-
-            // If the trader is a registered trader, check if they have free lots
-            if trader_index != u32::MAX {
-                let trader_state = self.get_trader_state_from_index_mut(trader_index);
-                match side {
-                    Side::Bid => {
-                        let quote_lots_free_to_use =
-                            trader_state.quote_lots_free.min(matched_quote_lots);
-                        trader_state.use_free_quote_lots(quote_lots_free_to_use);
-                        matching_engine_response.use_free_quote_lots(quote_lots_free_to_use);
-                    }
-                    Side::Ask => {
-                        let base_lots_free_to_use = trader_state
-                            .base_lots_free
-                            .min(inflight_order.matched_base_lots);
-                        trader_state.use_free_base_lots(base_lots_free_to_use);
-                        matching_engine_response.use_free_base_lots(base_lots_free_to_use);
-                    }
-                }
-
-                // If the order crosses and only uses deposited funds, then add the matched funds back to the trader's free funds
-                // Set the matching_engine_response lots_out to zero to set token withdrawals to zero
-                if order_packet.no_deposit_or_withdrawal() {
-                    match side {
-                        Side::Bid => {
-                            trader_state
-                                .deposit_free_base_lots(matching_engine_response.num_base_lots_out);
-                            matching_engine_response.num_base_lots_out = BaseLots::ZERO;
-                        }
-                        Side::Ask => {
-                            trader_state.deposit_free_quote_lots(
-                                matching_engine_response.num_quote_lots_out,
-                            );
-                            matching_engine_response.num_quote_lots_out = QuoteLots::ZERO;
-                        }
-                    }
-                }
-            }
 
             record_event_fn(MarketEvent::FillSummary {
                 client_order_id: order_packet.client_order_id(),
@@ -995,15 +978,6 @@ impl<
                     matching_engine_response.num_base_lots(),
                     matching_engine_response.num_quote_lots(),
                 );
-                return None;
-            }
-
-            // Check the trader had enough deposited funds to process the order
-            if order_packet.no_deposit_or_withdrawal()
-                && trader_index != u32::MAX
-                && !matching_engine_response.verify_no_deposit_or_withdrawal()
-            {
-                phoenix_log!("Insufficient deposited funds to process order");
                 return None;
             }
         } else {
@@ -1066,15 +1040,6 @@ impl<
                     }
                 }
 
-                // Check if trader has enough deposited funds to process the order
-                if order_packet.no_deposit_or_withdrawal()
-                    && trader_index != u32::MAX
-                    && !matching_engine_response.verify_no_deposit_or_withdrawal()
-                {
-                    phoenix_log!("Insufficient deposited funds to process order");
-                    return None;
-                }
-
                 // Record the place event
                 record_event_fn(MarketEvent::<MarketTraderId>::Place {
                     order_sequence_number: order_id.order_sequence_number,
@@ -1099,6 +1064,57 @@ impl<
                 self.order_sequence_number += 1;
             }
         }
+
+        // If the trader is a registered trader, check if they have free lots
+        if trader_index != u32::MAX {
+            let trader_state = self.get_trader_state_from_index_mut(trader_index);
+            match side {
+                Side::Bid => {
+                    let quote_lots_free_to_use = trader_state
+                        .quote_lots_free
+                        .min(matching_engine_response.num_quote_lots());
+                    trader_state.use_free_quote_lots(quote_lots_free_to_use);
+                    matching_engine_response.use_free_quote_lots(quote_lots_free_to_use);
+                }
+                Side::Ask => {
+                    let base_lots_free_to_use = trader_state
+                        .base_lots_free
+                        .min(matching_engine_response.num_base_lots());
+                    trader_state.use_free_base_lots(base_lots_free_to_use);
+                    matching_engine_response.use_free_base_lots(base_lots_free_to_use);
+                }
+            }
+
+            // If the order crosses and only uses deposited funds, then add the matched funds back to the trader's free funds
+            // Set the matching_engine_response lots_out to zero to set token withdrawals to zero
+            if order_packet.no_deposit_or_withdrawal() {
+                match side {
+                    Side::Bid => {
+                        trader_state
+                            .deposit_free_base_lots(matching_engine_response.num_base_lots_out);
+                        matching_engine_response.num_base_lots_out = BaseLots::ZERO;
+                    }
+                    Side::Ask => {
+                        trader_state
+                            .deposit_free_quote_lots(matching_engine_response.num_quote_lots_out);
+                        matching_engine_response.num_quote_lots_out = QuoteLots::ZERO;
+                    }
+                }
+
+                // Check if trader has enough deposited funds to process the order
+                if !matching_engine_response.verify_no_deposit() {
+                    phoenix_log!("Trader does not have enough deposited funds to process order");
+                    return None;
+                }
+
+                // Check that the matching engine response does not withdraw any base or quote lots
+                if !matching_engine_response.verify_no_withdrawal() {
+                    phoenix_log!("Matching engine response withdraws base or quote lots");
+                    return None;
+                }
+            }
+        }
+
         Some((placed_order_id, matching_engine_response))
     }
 
@@ -1231,9 +1247,9 @@ impl<
             if trader_index == current_trader_index as u64 {
                 match inflight_order.self_trade_behavior {
                     SelfTradeBehavior::Abort => return None,
-                    SelfTradeBehavior::CancelProvide | SelfTradeBehavior::DecrementTake => {
+                    SelfTradeBehavior::CancelProvide => {
                         // This block is entered if the self trade behavior for the crossing order is
-                        // CancelProvide or DecrementTake
+                        // CancelProvide
                         //
                         // We cancel the order from the book and free up the locked quote_lots or base_lots, but
                         // we do not claim them as part of the match
@@ -1246,21 +1262,46 @@ impl<
                             false,
                             record_event_fn,
                         )?;
-                        if inflight_order.self_trade_behavior == SelfTradeBehavior::DecrementTake {
-                            // In the case that the self trade behavior is DecrementTake, we decrement the
-                            // the base lot and adjusted quote lot budgets accordingly
-                            inflight_order.base_lot_budget = inflight_order
-                                .base_lot_budget
-                                .saturating_sub(num_base_lots_quoted);
-                            inflight_order.adjusted_quote_lot_budget =
-                                inflight_order.adjusted_quote_lot_budget.saturating_sub(
-                                    self.tick_size_in_quote_lots_per_base_unit
-                                        * order_id.price_in_ticks
-                                        * num_base_lots_quoted,
-                                );
-                        }
+                        inflight_order.match_limit -= 1;
+                    }
+                    SelfTradeBehavior::DecrementTake => {
+                        let base_lots_removed = inflight_order
+                            .base_lot_budget
+                            .min(
+                                inflight_order
+                                    .adjusted_quote_lot_budget
+                                    .unchecked_div::<QuoteLotsPerBaseUnit, BaseLots>(
+                                        order_id.price_in_ticks
+                                            * self.tick_size_in_quote_lots_per_base_unit,
+                                    ),
+                            )
+                            .min(num_base_lots_quoted);
+
+                        self.reduce_order_inner(
+                            current_trader_index,
+                            &order_id,
+                            inflight_order.side.opposite(),
+                            Some(base_lots_removed),
+                            false,
+                            false,
+                            record_event_fn,
+                        )?;
+                        // In the case that the self trade behavior is DecrementTake, we decrement the
+                        // the base lot and adjusted quote lot budgets accordingly
+                        inflight_order.base_lot_budget = inflight_order
+                            .base_lot_budget
+                            .saturating_sub(base_lots_removed);
+                        inflight_order.adjusted_quote_lot_budget =
+                            inflight_order.adjusted_quote_lot_budget.saturating_sub(
+                                self.tick_size_in_quote_lots_per_base_unit
+                                    * order_id.price_in_ticks
+                                    * base_lots_removed,
+                            );
                         // Self trades will count towards the match limit
                         inflight_order.match_limit -= 1;
+                        // If base_lots_removed < num_base_lots_quoted, then the order budget must be fully
+                        // exhausted
+                        inflight_order.should_terminate = base_lots_removed < num_base_lots_quoted;
                     }
                 }
                 continue;

--- a/src/state/markets/market_events.rs
+++ b/src/state/markets/market_events.rs
@@ -38,4 +38,15 @@ pub enum MarketEvent<MarketTraderId: BorshDeserialize + BorshDeserialize> {
     Fee {
         fees_collected_in_quote_lots: QuoteLots,
     },
+    TimeInForce {
+        order_sequence_number: u64,
+        last_valid_slot: u64,
+        last_valid_unix_timestamp_in_seconds: u64,
+    },
+    ExpiredOrder {
+        maker_id: MarketTraderId,
+        order_sequence_number: u64,
+        price_in_ticks: Ticks,
+        base_lots_removed: BaseLots,
+    },
 }

--- a/src/state/markets/market_traits.rs
+++ b/src/state/markets/market_traits.rs
@@ -175,6 +175,7 @@ pub(crate) trait WritableMarket<
         trader: &MarketTraderId,
         order_packet: MarketOrderPacket,
         record_event_fn: &mut dyn FnMut(MarketEvent<MarketTraderId>),
+        get_clock_fn: &mut dyn FnMut() -> (u64, u64),
     ) -> Option<(Option<MarketOrderId>, MatchingEngineResponse)>;
 
     fn cancel_order(

--- a/src/state/markets/market_traits.rs
+++ b/src/state/markets/market_traits.rs
@@ -43,6 +43,9 @@ pub trait OrderId {
 
 pub trait RestingOrder {
     fn size(&self) -> u64;
+    fn last_valid_slot(&self) -> Option<u64>;
+    fn last_valid_unix_timestamp_in_seconds(&self) -> Option<u64>;
+    fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool;
 }
 
 /// A wrapper around an matching algorithm implementation that allows arbitrary structs to be
@@ -65,7 +68,20 @@ pub trait Market<
     }
 
     fn get_ladder(&self, levels: u64) -> Ladder {
-        let ladder = self.get_typed_ladder(levels);
+        self.get_ladder_with_expiration(levels, None, None)
+    }
+
+    fn get_ladder_with_expiration(
+        &self,
+        levels: u64,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
+    ) -> Ladder {
+        let ladder = self.get_typed_ladder_with_expiration(
+            levels,
+            last_valid_slot,
+            last_valid_unix_timestamp_in_seconds,
+        );
         Ladder {
             bids: ladder
                 .bids
@@ -87,6 +103,17 @@ pub trait Market<
     }
 
     fn get_typed_ladder(&self, levels: u64) -> TypedLadder {
+        self.get_typed_ladder_with_expiration(levels, None, None)
+    }
+
+    fn get_typed_ladder_with_expiration(
+        &self,
+        levels: u64,
+        last_valid_slot: Option<u64>,
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
+    ) -> TypedLadder {
+        let slot_expiration = last_valid_slot.unwrap_or_else(|| 0);
+        let unix_timestamp_expiration = last_valid_unix_timestamp_in_seconds.unwrap_or_else(|| 0);
         let mut bids = vec![];
         let mut asks = vec![];
         for (side, book) in [(Side::Bid, &mut bids), (Side::Ask, &mut asks)].iter_mut() {
@@ -94,8 +121,12 @@ pub trait Market<
                 &self
                     .get_book(*side)
                     .iter()
-                    .map(|(order_id, resting_order)| {
-                        (order_id.price_in_ticks(), resting_order.size())
+                    .filter_map(|(order_id, resting_order)| {
+                        if resting_order.is_expired(slot_expiration, unix_timestamp_expiration) {
+                            None
+                        } else {
+                            Some((order_id.price_in_ticks(), resting_order.size()))
+                        }
                     })
                     .group_by(|(price_in_ticks, _)| *price_in_ticks)
                     .into_iter()

--- a/src/state/markets/test_market.rs
+++ b/src/state/markets/test_market.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::quantities::*;
 use crate::state::markets::*;
@@ -31,6 +32,11 @@ fn setup_market_with_params(
     );
     dex.set_fee(fees);
     *dex
+}
+
+/// Dummy placeholder clock function
+fn get_clock_fn() -> (u64, u64) {
+    (0, 0)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -78,6 +84,7 @@ fn layer_orders(
             &trader,
             OrderPacket::new_limit_order_default(side, *p, *s * adj),
             event_recorder,
+            &mut get_clock_fn,
         )
         .unwrap();
     }
@@ -165,6 +172,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -204,6 +212,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     println!(
@@ -232,6 +241,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
 
@@ -274,6 +284,7 @@ fn test_market_simple() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
 
@@ -379,6 +390,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 100, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     // Cannot place post only order that would match
@@ -387,6 +399,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Ask, 100, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -395,6 +408,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Ask, 102, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -402,6 +416,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 101, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -411,6 +426,7 @@ fn test_post_only_default() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 102, 1),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -436,6 +452,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 100, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     // Cannot place post only order that would match if reject flag is true
@@ -444,6 +461,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 100, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -452,6 +470,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 102, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -459,6 +478,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 101, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -468,6 +488,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 102, 1, 0, true, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -477,6 +498,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 100, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -486,6 +508,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 102, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -505,6 +528,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Ask, 1, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -514,6 +538,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 1, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -523,6 +548,7 @@ fn test_post_only_rejection() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 0, 1, 0, false, false),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -546,6 +572,7 @@ fn test_cancel_all() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 1),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -557,6 +584,7 @@ fn test_cancel_all() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 102 + i, 1),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -580,6 +608,7 @@ fn test_limit_orders_with_self_trade() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 5),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     let ladder = market.get_typed_ladder(1);
@@ -591,6 +620,7 @@ fn test_limit_orders_with_self_trade() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     let mut res = MatchingEngineResponse::default();
@@ -613,6 +643,7 @@ fn test_limit_orders_with_self_trade() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
     let (order, matching_engine_response) = market
@@ -628,6 +659,7 @@ fn test_limit_orders_with_self_trade() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -657,6 +689,7 @@ fn test_limit_orders_with_self_trade() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -690,6 +723,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 5),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -698,6 +732,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 95, 15),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -706,6 +741,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Ask, 95, 15,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -715,6 +751,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 5),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -729,6 +766,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 20),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -744,6 +782,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -753,6 +792,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Bid, 101, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     let (order, matching_engine_response) = market
@@ -760,6 +800,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 100, 50),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -777,6 +818,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Bid, 105, 55,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -786,6 +828,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 20),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -807,6 +850,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 100, 50),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -828,6 +872,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 120, 50),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -835,6 +880,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Ask, 120, 25),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -844,6 +890,7 @@ fn test_limit_orders_with_free_lots() {
             &taker,
             OrderPacket::new_limit_order_default(Side::Ask, 110, 25),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     let (order, matching_engine_response) = market
@@ -851,6 +898,7 @@ fn test_limit_orders_with_free_lots() {
             &trader,
             OrderPacket::new_limit_order_default(Side::Bid, 111, 75),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_some());
@@ -888,6 +936,7 @@ fn test_orders_with_only_free_funds() {
             &taker,
             OrderPacket::new_post_only(Side::Bid, 100, 5, 0, false, true,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -896,6 +945,7 @@ fn test_orders_with_only_free_funds() {
             &trader,
             OrderPacket::new_post_only(Side::Bid, 100, 5, 0, false, false,),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -913,6 +963,7 @@ fn test_orders_with_only_free_funds() {
                 true,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -929,6 +980,7 @@ fn test_orders_with_only_free_funds() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -946,6 +998,7 @@ fn test_orders_with_only_free_funds() {
                 true,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -962,6 +1015,7 @@ fn test_orders_with_only_free_funds() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -978,6 +1032,7 @@ fn test_orders_with_only_free_funds() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -995,6 +1050,7 @@ fn test_orders_with_only_free_funds() {
                 true,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 }
@@ -1010,6 +1066,7 @@ fn seed_market_with_orders(
                 trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10),
                 record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1017,6 +1074,7 @@ fn seed_market_with_orders(
                 trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10),
                 record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1051,6 +1109,7 @@ fn test_fok_and_ioc_limit_1() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_none());
@@ -1076,6 +1135,7 @@ fn test_fok_and_ioc_limit_1() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_none());
@@ -1110,6 +1170,7 @@ fn test_fok_and_ioc_limit_2() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
     assert!(market
@@ -1124,6 +1185,7 @@ fn test_fok_and_ioc_limit_2() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 }
@@ -1158,6 +1220,7 @@ fn test_fok_and_ioc_limit_3() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1181,6 +1244,7 @@ fn test_fok_and_ioc_limit_3() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1223,6 +1287,7 @@ fn test_fok_and_ioc_limit_4() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1252,6 +1317,7 @@ fn test_fok_and_ioc_limit_4() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o.is_none());
@@ -1294,6 +1360,7 @@ fn test_fok_and_ioc_limit_5() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
     assert!(market
@@ -1308,6 +1375,7 @@ fn test_fok_and_ioc_limit_5() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 
@@ -1328,6 +1396,7 @@ fn test_fok_and_ioc_limit_5() {
                     false,
                 ),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_none(),
         "Only one of num_base_lots or num_quote_lots should be set"
@@ -1381,6 +1450,7 @@ fn test_fok_with_slippage_1() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1388,6 +1458,7 @@ fn test_fok_with_slippage_1() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1424,6 +1495,7 @@ fn test_fok_with_slippage_1() {
                 min_base_lots_out.as_u64(),
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     println!("matching_engine_response: {:?}", matching_engine_response);
@@ -1483,6 +1555,7 @@ fn test_fok_with_slippage_2() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1490,6 +1563,7 @@ fn test_fok_with_slippage_2() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1507,6 +1581,7 @@ fn test_fok_with_slippage_2() {
                     .as_u64()
             ), // 2 full levels, 1 partial level
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_none());
 }
@@ -1529,6 +1604,7 @@ fn test_fok_with_slippage_3() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Bid, 100 - i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
         assert!(market
@@ -1536,6 +1612,7 @@ fn test_fok_with_slippage_3() {
                 &trader,
                 OrderPacket::new_post_only_default(Side::Ask, 100 + i, 10000 * i),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
     }
@@ -1573,6 +1650,7 @@ fn test_fok_with_slippage_3() {
                 min_quote_lots_out.as_u64(),
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(order.is_none());
@@ -1636,6 +1714,7 @@ fn test_fees_basic() {
             &trader,
             OrderPacket::new_post_only_default(Side::Bid, 9900, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
     assert!(market
@@ -1643,6 +1722,7 @@ fn test_fees_basic() {
             &trader,
             OrderPacket::new_post_only_default(Side::Ask, 10100, 10),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .is_some());
 
@@ -1659,6 +1739,7 @@ fn test_fees_basic() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o_id.is_none());
@@ -1685,6 +1766,7 @@ fn test_fees_basic() {
                 false,
             ),
             &mut record_event_fn,
+            &mut get_clock_fn,
         )
         .unwrap();
     assert!(o_id.is_none());
@@ -1720,6 +1802,7 @@ fn test_evict_order() {
                 &trader,
                 OrderPacket::new_post_only_default(side, price.as_u64(), 1),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             );
         }
         let direction = match side {
@@ -1731,6 +1814,7 @@ fn test_evict_order() {
             &stink_order,
             OrderPacket::new_post_only_default(side, stink_price.as_u64(), 99),
             &mut record_event_fn,
+            &mut get_clock_fn,
         );
         // Order must be more aggressive than the least aggressive order in a full book
         assert!(market
@@ -1738,6 +1822,7 @@ fn test_evict_order() {
                 &stink_order,
                 OrderPacket::new_post_only_default(side, stink_price.as_u64(), 99),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_none());
         let mut event_recorder = VecDeque::new();
@@ -1751,6 +1836,7 @@ fn test_evict_order() {
                     99
                 ),
                 &mut record_event_fn,
+                &mut get_clock_fn,
             )
             .is_some());
 
@@ -1801,7 +1887,12 @@ fn test_reduce_order() {
     {
         let mut record_event_fn = |e: MarketEvent<TraderId>| event_recorder.push_back(e);
         market
-            .place_order(&maker, order_packet, &mut record_event_fn)
+            .place_order(
+                &maker,
+                order_packet,
+                &mut record_event_fn,
+                &mut get_clock_fn,
+            )
             .unwrap();
     }
 
@@ -1857,7 +1948,12 @@ fn test_reduce_order() {
     {
         let mut record_event_fn = |e: MarketEvent<TraderId>| event_recorder.push_back(e);
         market
-            .place_order(&random_maker, order_packet, &mut record_event_fn)
+            .place_order(
+                &random_maker,
+                order_packet,
+                &mut record_event_fn,
+                &mut get_clock_fn,
+            )
             .unwrap();
         assert!(
             market
@@ -1919,4 +2015,208 @@ fn test_reduce_order() {
     }
 
     assert!(market.bids.get(&order_id).is_none());
+}
+
+#[test]
+fn test_tif() {
+    let mut rng = StdRng::seed_from_u64(2);
+    let mut market = setup_market();
+    let maker = rng.gen::<u128>();
+
+    pub struct MockClock {
+        slot: u64,
+        timestamp: u64,
+    }
+
+    let now = SystemTime::now();
+    let exp = now
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .checked_add(1000)
+        .unwrap();
+
+    let order_packet_unix_timestamp_tif = OrderPacket::PostOnly {
+        side: Side::Bid,
+        price_in_ticks: Ticks::new(1000),
+        num_base_lots: BaseLots::new(100),
+        client_order_id: rng.gen::<u128>(),
+        use_only_deposited_funds: false,
+        reject_post_only: true,
+        last_valid_slot: None,
+        last_valid_unix_timestamp_in_seconds: Some(exp),
+    };
+
+    let order_packet_slot_tif = OrderPacket::PostOnly {
+        side: Side::Bid,
+        price_in_ticks: Ticks::new(1000),
+        num_base_lots: BaseLots::new(100),
+        client_order_id: rng.gen::<u128>(),
+        use_only_deposited_funds: false,
+        reject_post_only: true,
+        last_valid_slot: Some(2000),
+        last_valid_unix_timestamp_in_seconds: None,
+    };
+
+    for order_packet in [order_packet_unix_timestamp_tif, order_packet_slot_tif] {
+        let mut mock_clock = MockClock {
+            slot: 1000,
+            timestamp: now.duration_since(UNIX_EPOCH).unwrap().as_secs(),
+        };
+        let mut event_recorder = VecDeque::new();
+        let mut record_event_fn = |e: MarketEvent<TraderId>| event_recorder.push_back(e);
+
+        {
+            let expired_mock_clock = MockClock {
+                slot: 3000,
+                timestamp: now.duration_since(UNIX_EPOCH).unwrap().as_secs() + 2000,
+            };
+            let mut mock_clock_fn = || (expired_mock_clock.slot, expired_mock_clock.timestamp);
+            assert!(market
+                .place_order(
+                    &maker,
+                    order_packet,
+                    &mut record_event_fn,
+                    &mut mock_clock_fn,
+                )
+                .is_none());
+        }
+
+        {
+            let mut mock_clock_fn = || (mock_clock.slot, mock_clock.timestamp);
+            market
+                .place_order(
+                    &maker,
+                    order_packet,
+                    &mut record_event_fn,
+                    &mut mock_clock_fn,
+                )
+                .unwrap();
+        }
+
+        let taker = rng.gen::<u128>();
+
+        if order_packet.get_last_valid_slot().is_some() {
+            mock_clock.slot += 500;
+        } else {
+            mock_clock.timestamp += 500;
+        }
+        let (_, matching_engine_response) = {
+            let mut mock_clock_fn = || (mock_clock.slot, mock_clock.timestamp);
+            market
+                .place_order(
+                    &taker,
+                    OrderPacket::new_ioc_by_lots(
+                        Side::Ask,
+                        0,
+                        10,
+                        SelfTradeBehavior::Abort,
+                        None,
+                        rng.gen::<u128>(),
+                        false,
+                    ),
+                    &mut record_event_fn,
+                    &mut mock_clock_fn,
+                )
+                .unwrap()
+        };
+
+        assert!(matching_engine_response.num_quote_lots_out > QuoteLots::ZERO);
+
+        if order_packet.get_last_valid_slot().is_some() {
+            mock_clock.slot += 500;
+        } else {
+            mock_clock.timestamp += 500;
+        }
+
+        let (_, matching_engine_response) = {
+            let mut mock_clock_fn = || (mock_clock.slot, mock_clock.timestamp);
+            market
+                .place_order(
+                    &taker,
+                    OrderPacket::new_ioc_by_lots(
+                        Side::Ask,
+                        0,
+                        10,
+                        SelfTradeBehavior::Abort,
+                        None,
+                        rng.gen::<u128>(),
+                        false,
+                    ),
+                    &mut record_event_fn,
+                    &mut mock_clock_fn,
+                )
+                .unwrap()
+        };
+
+        assert!(matching_engine_response.num_quote_lots_out > QuoteLots::ZERO);
+
+        if order_packet.get_last_valid_slot().is_some() {
+            mock_clock.slot += 1;
+        } else {
+            mock_clock.timestamp += 1;
+        }
+
+        let (_, matching_engine_response) = {
+            let mut mock_clock_fn = || (mock_clock.slot, mock_clock.timestamp);
+            market
+                .place_order(
+                    &taker,
+                    OrderPacket::new_ioc_by_lots(
+                        Side::Ask,
+                        0,
+                        10,
+                        SelfTradeBehavior::Abort,
+                        None,
+                        rng.gen::<u128>(),
+                        false,
+                    ),
+                    &mut record_event_fn,
+                    &mut mock_clock_fn,
+                )
+                .unwrap()
+        };
+
+        // Assert that TIF kicked in
+        assert_eq!(matching_engine_response.num_quote_lots_out, QuoteLots::ZERO);
+
+        for (i, event) in event_recorder.iter().enumerate() {
+            match i {
+                0 => {
+                    assert!(matches!(event, MarketEvent::Place { .. }));
+                }
+                1 => {
+                    assert!(matches!(event, MarketEvent::TimeInForce { .. }));
+                }
+                2 | 4 => {
+                    assert!(matches!(event, MarketEvent::Fill { .. }));
+                }
+                3 | 5 | 7 => {
+                    assert!(matches!(event, MarketEvent::FillSummary { .. }));
+                }
+                6 => {
+                    if let MarketEvent::ExpiredOrder {
+                        maker_id,
+                        order_sequence_number,
+                        price_in_ticks,
+                        base_lots_removed,
+                    } = event
+                    {
+                        assert_eq!(maker_id, &maker);
+                        assert_eq!(
+                            Side::from_order_sequence_number(*order_sequence_number),
+                            Side::Bid
+                        );
+                        assert_eq!(*price_in_ticks, Ticks::new(1000));
+                        assert_eq!(*base_lots_removed, BaseLots::new(80));
+                    } else {
+                        panic!("Invalid event")
+                    }
+                }
+                _ => {
+                    panic!("Invalid event")
+                }
+            }
+        }
+    }
 }

--- a/src/state/matching_engine_response.rs
+++ b/src/state/matching_engine_response.rs
@@ -94,8 +94,13 @@ impl MatchingEngineResponse {
     }
 
     #[inline(always)]
-    pub fn verify_no_deposit_or_withdrawal(&self) -> bool {
+    pub fn verify_no_deposit(&self) -> bool {
         self.num_base_lots_in + self.num_base_lots_posted == self.num_free_base_lots_used
             && self.num_quote_lots_in + self.num_quote_lots_posted == self.num_free_quote_lots_used
+    }
+
+    #[inline(always)]
+    pub fn verify_no_withdrawal(&self) -> bool {
+        self.num_base_lots_out == BaseLots::ZERO && self.num_quote_lots_out == QuoteLots::ZERO
     }
 }

--- a/src/state/order_schema/order_packet.rs
+++ b/src/state/order_schema/order_packet.rs
@@ -41,6 +41,12 @@ pub enum OrderPacket {
         /// Using only deposited funds will allow the trader to pass in less accounts per instruction and
         /// save transaction space as well as compute. This is only for traders who have a seat
         use_only_deposited_funds: bool,
+
+        /// If this is set, the order will be invalid after the specified slot
+        last_valid_slot: Option<u64>,
+
+        /// If this is set, the order will be invalid after the specified unix timestamp
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     },
 
     /// This order type is used to place a limit order on the book
@@ -68,6 +74,12 @@ pub enum OrderPacket {
         /// Using only deposited funds will allow the trader to pass in less accounts per instruction and
         /// save transaction space as well as compute. This is only for traders who have a seat
         use_only_deposited_funds: bool,
+
+        /// If this is set, the order will be invalid after the specified slot
+        last_valid_slot: Option<u64>,
+
+        /// If this is set, the order will be invalid after the specified unix timestamp
+        last_valid_unix_timestamp_in_seconds: Option<u64>,
     },
 
     /// This order type is used to place an order that will be matched against existing resting orders
@@ -169,6 +181,8 @@ impl OrderPacket {
             client_order_id: 0,
             reject_post_only: true,
             use_only_deposited_funds: false,
+            last_valid_slot: None,
+            last_valid_unix_timestamp_in_seconds: None,
         }
     }
 
@@ -185,6 +199,8 @@ impl OrderPacket {
             client_order_id,
             reject_post_only: true,
             use_only_deposited_funds: false,
+            last_valid_slot: None,
+            last_valid_unix_timestamp_in_seconds: None,
         }
     }
 
@@ -201,6 +217,8 @@ impl OrderPacket {
             client_order_id,
             reject_post_only: false,
             use_only_deposited_funds: false,
+            last_valid_slot: None,
+            last_valid_unix_timestamp_in_seconds: None,
         }
     }
 
@@ -219,6 +237,8 @@ impl OrderPacket {
             client_order_id,
             reject_post_only,
             use_only_deposited_funds,
+            last_valid_slot: None,
+            last_valid_unix_timestamp_in_seconds: None,
         }
     }
 
@@ -268,6 +288,8 @@ impl OrderPacket {
             match_limit,
             client_order_id,
             use_only_deposited_funds,
+            last_valid_slot: None,
+            last_valid_unix_timestamp_in_seconds: None,
         }
     }
 
@@ -547,5 +569,47 @@ impl OrderPacket {
                 ..
             } => *old_price_in_ticks = Some(price_in_ticks),
         }
+    }
+
+    pub fn get_last_valid_slot(&self) -> Option<u64> {
+        match self {
+            Self::PostOnly {
+                last_valid_slot, ..
+            } => *last_valid_slot,
+            Self::Limit {
+                last_valid_slot, ..
+            } => *last_valid_slot,
+            Self::ImmediateOrCancel { .. } => None,
+        }
+    }
+
+    pub fn get_last_valid_unix_timestamp_in_seconds(&self) -> Option<u64> {
+        match self {
+            Self::PostOnly {
+                last_valid_unix_timestamp_in_seconds,
+                ..
+            } => *last_valid_unix_timestamp_in_seconds,
+            Self::Limit {
+                last_valid_unix_timestamp_in_seconds,
+                ..
+            } => *last_valid_unix_timestamp_in_seconds,
+            Self::ImmediateOrCancel { .. } => None,
+        }
+    }
+
+    pub fn is_expired(&self, current_slot: u64, current_unix_timestamp_in_seconds: u64) -> bool {
+        if let Some(last_valid_slot) = self.get_last_valid_slot() {
+            if current_slot > last_valid_slot {
+                return true;
+            }
+        }
+        if let Some(last_valid_unix_timestamp_in_seconds) =
+            self.get_last_valid_unix_timestamp_in_seconds()
+        {
+            if current_unix_timestamp_in_seconds > last_valid_unix_timestamp_in_seconds {
+                return true;
+            }
+        }
+        false
     }
 }

--- a/tests/test_phoenix.rs
+++ b/tests/test_phoenix.rs
@@ -3,6 +3,7 @@ use ellipsis_client::EllipsisClient;
 use phoenix::phoenix_log_authority;
 use phoenix::program::deposit::DepositParams;
 use phoenix::program::instruction_builders::*;
+use phoenix::program::new_order::CondensedOrder;
 use phoenix::program::new_order::MultipleOrderPacket;
 use phoenix::program::MarketHeader;
 use phoenix::quantities::WrapperU64;
@@ -2280,24 +2281,32 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Place multiple post only orders successfully
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
-                sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(9.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(8.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(9.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
         vec![
-            (
-                sdk.float_price_to_ticks(10.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(11.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(10.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(11.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
     );
 
@@ -2332,25 +2341,25 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure free funds order doesnt place if not enough base lots but enough quote lots
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
+                sdk.raw_base_units_to_base_lots(9.0),
             ),
-            (
-                sdk.float_price_to_ticks(9.0),
+            CondensedOrder::new_default(
+                sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(10.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(12.0),
                 sdk.raw_base_units_to_base_lots(4.0),
             ),
@@ -2373,28 +2382,38 @@ async fn test_phoenix_place_multiple_limit_orders() {
 
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
-                sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(9.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(3.0),
-                sdk.raw_base_units_to_base_lots(1.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(8.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(9.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(3.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(1.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
         vec![
-            (
-                sdk.float_price_to_ticks(10.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(11.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(10.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(11.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
     );
 
@@ -2413,28 +2432,38 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // place multiple post only orders successfully with free funds
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
-                sdk.float_price_to_ticks(8.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(9.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(8.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(9.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
         vec![
-            (
-                sdk.float_price_to_ticks(17.0),
-                sdk.raw_base_units_to_base_lots(10.0),
-            ),
-            (
-                sdk.float_price_to_ticks(17.0),
-                sdk.raw_base_units_to_base_lots(5.0),
-            ),
-            (
-                sdk.float_price_to_ticks(12.0),
-                sdk.raw_base_units_to_base_lots(5.0),
-            ),
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(17.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(10.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(17.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(5.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
+            CondensedOrder {
+                price_in_ticks: sdk.float_price_to_ticks(12.0),
+                size_in_base_lots: sdk.raw_base_units_to_base_lots(5.0),
+                last_valid_slot: None,
+                last_valid_unix_timestamp_in_seconds: None,
+            },
         ],
     );
     let new_order_ix = create_new_multiple_order_with_free_funds_instruction(
@@ -2474,21 +2503,21 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure we can't place orders in cross against themselves
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(8.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2512,25 +2541,25 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure we can't place orders in cross against themselves, different variation
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(29.0),
                 sdk.raw_base_units_to_base_lots(1.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(19.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(30.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(25.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2589,21 +2618,21 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Ensure we can't place orders in cross against the existing book
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(8.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(10.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(11.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2626,11 +2655,11 @@ async fn test_phoenix_place_multiple_limit_orders() {
 
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(20.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(9.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
@@ -2656,46 +2685,46 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Currently have 20 base units and 170 quote units available
     let multiple_order_packet = MultipleOrderPacket::new_default(
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(5.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(4.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(3.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(5.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
-            (
+            CondensedOrder::new_default(
                 //this order is all of the extra quote lots we need to deposit
                 sdk.float_price_to_ticks(4.0),
                 sdk.raw_base_units_to_base_lots(10.0),
             ),
         ],
         vec![
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(105.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(103.0),
                 sdk.raw_base_units_to_base_lots(5.0),
             ),
-            (
+            CondensedOrder::new_default(
                 //this order is all of the extra base lots we need to deposit
                 sdk.float_price_to_ticks(102.0),
                 sdk.raw_base_units_to_base_lots(5.0),
@@ -2751,7 +2780,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Send 100 orders on each side to verify there is enough compute to do so
     let bids = (1..101)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2759,7 +2788,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
         .collect::<Vec<_>>();
     let asks = (1..101)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2790,7 +2819,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
     //Send multiple orders in cross via the second maker - verify this throws an error
     let bids = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(101.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2798,7 +2827,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
         .collect::<Vec<_>>();
     let asks = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(99.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2822,7 +2851,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
     // Send multiple orders in cross via the second maker, this time with post only rejection set to false - verify this succeeds
     let bids = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(101.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -2830,7 +2859,7 @@ async fn test_phoenix_place_multiple_limit_orders() {
         .collect::<Vec<_>>();
     let asks = (1..30)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(99.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(10.0),
             )
@@ -3015,7 +3044,7 @@ async fn test_phoenix_place_multiple_memory_management() {
     // Send 40 orders on each side to verify there is enough compute to do so
     let bids = (1..41)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 - (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(1.0),
             )
@@ -3023,7 +3052,7 @@ async fn test_phoenix_place_multiple_memory_management() {
         .collect::<Vec<_>>();
     let asks = (1..41)
         .map(|i| {
-            (
+            CondensedOrder::new_default(
                 sdk.float_price_to_ticks(100.0 + (i as f64 * 0.1)),
                 sdk.raw_base_units_to_base_lots(1.0),
             )
@@ -3098,10 +3127,10 @@ async fn test_phoenix_place_multiple_limit_orders_adversarial() {
     // Stuff the book with 1 lots
     loop {
         let bids = (start..start + 30)
-            .map(|_| (sdk.float_price_to_ticks(99.0), 1))
+            .map(|_| CondensedOrder::new_default(sdk.float_price_to_ticks(99.0), 1))
             .collect::<Vec<_>>();
         let asks = (start..start + 30)
-            .map(|_| (sdk.float_price_to_ticks(100.0), 1))
+            .map(|_| CondensedOrder::new_default(sdk.float_price_to_ticks(100.0), 1))
             .collect::<Vec<_>>();
 
         let multiple_order_packet = MultipleOrderPacket::new_default(bids, asks);


### PR DESCRIPTION
Time-in-force (TIF) orders for Phoenix v1.

Changes:
- Uses the padding on the FIFORestingOrder to store and expiration slot and an expiration time
- Modifies the OrderPacket struct to enable specification of expiration
- Injects logic into the matching engine to skip orders that are expired