### PR TITLE
Address minor ordering issue in PlaceMultipleOrders

### DIFF
--- a/src/program/processor/new_order.rs
+++ b/src/program/processor/new_order.rs
@@ -569,7 +569,10 @@ fn process_multiple_new_orders<'a, 'info>(
                 last_valid_unix_timestamp_in_seconds,
             } in book_orders
                 .iter()
-                .sorted_by(|o1, o2| o1.price_in_ticks.cmp(&o2.price_in_ticks))
+                .sorted_by(|o1, o2| match side {
+                    Side::Bid => o2.price_in_ticks.cmp(&o1.price_in_ticks),
+                    Side::Ask => o1.price_in_ticks.cmp(&o2.price_in_ticks),
+                })
                 .group_by(|o| {
                     (
                         o.price_in_ticks,


### PR DESCRIPTION
The logic in PlaceMultipleOrders sorts both bids and asks from lowest price to highest price. When combined with the feature to silently fail on insufficient funds, this results in slightly unexpected behavior where the wider (less aggressive) levels of the bid orders are placed before the tighter levels. If the user runs out of quote collateral in this process, the wide bid levels will be displayed but the tight levels will be silently omitted.

The opposite but desired effect is true for the ask orders.