### PR TITLE
Rename Phoenix to Phoenix Legacy in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # phoenix
 
-Phoenix is an on-chain orderbook that operates without a crank.
+Phoenix Legacy is an on-chain orderbook that operates without a crank.
 
 ### Documentation
 
@@ -8,15 +8,15 @@ Documentation and instructions on how to interact with the program are available
 
 ### Licensing
 
-The primary license for Phoenix is the Business Source License 1.1 (`BUSL-1.1`), which can be found at [`LICENSE`](https://github.com/Ellipsis-Labs/phoenix-v1/blob/master/LICENSE).
+The primary license for Phoenix Legacy is the Business Source License 1.1 (`BUSL-1.1`), which can be found at [`LICENSE`](https://github.com/Ellipsis-Labs/phoenix-v1/blob/master/LICENSE).
 
 ### Audits
 
-Phoenix has been audited by OtterSec. The audit report can be found at [audits/OtterSec.pdf](https://github.com/Ellipsis-Labs/phoenix-v1/blob/master/audits/OtterSec.pdf).
+Phoenix Legacy has been audited by OtterSec. The audit report can be found at [audits/OtterSec.pdf](https://github.com/Ellipsis-Labs/phoenix-v1/blob/master/audits/OtterSec.pdf).
 
 ### Bug Bounty
 
-Information on the bug bounty program for Phoenix can be found at [SECURITY.md](https://github.com/Ellipsis-Labs/phoenix-v1/blob/master/SECURITY.md).
+Information on the bug bounty program for Phoenix Legacy can be found at [SECURITY.md](https://github.com/Ellipsis-Labs/phoenix-v1/blob/master/SECURITY.md).
 
 ### Build Verification
 
@@ -41,4 +41,3 @@ To run the tests, run:
 ```
 ./test.sh
 ```
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
-# Phoenix Bug Bounty Program
+# Phoenix Legacy Bug Bounty Program
 
 ## Bug Bounty Overview
 
-This bug bounty program is specifically for [Phoenix](https://github.com/Ellipsis-Labs/phoenix-v1)’s smart contract code and [Sokoban](https://github.com/Ellipsis-Labs/sokoban/blob/master/src/red_black_tree.rs)’s red-black tree implementation. All relevant code is open source.
+This bug bounty program is specifically for [Phoenix Legacy](https://github.com/Ellipsis-Labs/phoenix-v1)’s smart contract code and [Sokoban](https://github.com/Ellipsis-Labs/sokoban/blob/master/src/red_black_tree.rs)’s red-black tree implementation. All relevant code is open source.
 
 Our bug bounty security guidelines are based on [Immunefi’s vulnerability severity classification system](https://immunefi.com/immunefi-vulnerability-severity-classification-system-v2-2/), and are subject to change at any time.
 


### PR DESCRIPTION
Updates user-facing docs to reflect the Phoenix Legacy name. No code or behavior changes.