### PR TITLE
feat: create an instruction to reclaim the rent of limit order seats if the market has been deleted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,17 @@ overflow-checks = true
 [dependencies]
 shank = "=0.0.12"
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-associated-token-account = { version = "=1.1.1", features = [ "no-entrypoint" ] } 
+spl-associated-token-account = { version = "=1.1.1", features = [
+    "no-entrypoint",
+] }
 solana-program = "=1.14.9"
 borsh = "=0.9.3"
 bytemuck = "=1.13.0"
-lib-sokoban = "=0.3.0" 
+lib-sokoban = "=0.3.0"
 num_enum = "=0.5.9"
 itertools = "=0.10.5"
 thiserror = "=1.0.38"
-ellipsis-macros = "=0.1.1" 
+ellipsis-macros = "=0.1.1"
 solana-security-txt = "=1.1.0"
 static_assertions = "=1.1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,47 +125,7 @@ pub fn process_instruction(
     }
 
     if let PhoenixInstruction::DeleteSeat = instruction {
-        let market = next_account_info(&mut accounts.iter())?;
-        let seat = SeatAccountInfo::new(next_account_info(&mut accounts.iter())?, market.key)?;
-        let funding_key = next_account_info(&mut accounts.iter())?;
-
-        if market.data_is_empty() && *market.owner == solana_program::system_program::id() {
-            phoenix_log!("Market is empty, reclaiming seat's lamports");
-        } else {
-            // There are other cases that fall into this category.
-            // All of those cases involve user misconfiguation, so we return an error out of caution.
-            phoenix_log!("Market is not empty, cannot reclaim seat's lamports");
-            return Err(ProgramError::IllegalOwner);
-        }
-
-        let (trader, payer) = {
-            let seat = seat.load_mut()?;
-            (seat.trader, seat.funding_key)
-        };
-
-        if payer == Pubkey::default() {
-            phoenix_log!("Seat's lamports will be reclaimed to the trader");
-            assert_with_msg(
-                trader == *funding_key.key,
-                ProgramError::InvalidAccountData,
-                "Funding key mismatch",
-            )?;
-        } else {
-            phoenix_log!("Seat's lamports will be reclaimed to the funder");
-            assert_with_msg(
-                payer == *funding_key.key,
-                ProgramError::InvalidAccountData,
-                "Funding key mismatch",
-            )?;
-        }
-
-        let destination_starting_lamports = funding_key.lamports();
-        **funding_key.lamports.borrow_mut() = destination_starting_lamports + seat.lamports();
-        **seat.lamports.borrow_mut() = 0;
-        seat.assign(&solana_program::system_program::id());
-        seat.realloc(0, false)?;
-        phoenix_log!("Seat has been removed");
-        return Ok(());
+        return delete_seat_account(accounts);
     }
 
     let (program_accounts, accounts) = accounts.split_at(4);
@@ -412,5 +372,49 @@ pub fn process_instruction(
     if !order_ids.is_empty() {
         set_return_data(order_ids.try_to_vec()?.as_ref());
     }
+    Ok(())
+}
+
+fn delete_seat_account(&accounts: &[AccountInfo]) -> ProgramResult {
+    let market = next_account_info(&mut accounts.iter())?;
+    let seat = SeatAccountInfo::new(next_account_info(&mut accounts.iter())?, market.key)?;
+    let funding_key = next_account_info(&mut accounts.iter())?;
+
+    if market.data_is_empty() && *market.owner == solana_program::system_program::id() {
+        phoenix_log!("Market is empty, reclaiming seat's lamports");
+    } else {
+        // There are other cases that fall into this category.
+        // All of those cases involve user misconfiguation, so we return an error out of caution.
+        phoenix_log!("Market is not empty, cannot reclaim seat's lamports");
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    let (trader, payer) = {
+        let seat = seat.load_mut()?;
+        (seat.trader, seat.funding_key)
+    };
+
+    if payer == Pubkey::default() {
+        phoenix_log!("Seat's lamports will be reclaimed to the trader");
+        assert_with_msg(
+            trader == *funding_key.key,
+            ProgramError::InvalidAccountData,
+            "Funding key mismatch",
+        )?;
+    } else {
+        phoenix_log!("Seat's lamports will be reclaimed to the funder");
+        assert_with_msg(
+            payer == *funding_key.key,
+            ProgramError::InvalidAccountData,
+            "Funding key mismatch",
+        )?;
+    }
+
+    let destination_starting_lamports = funding_key.lamports();
+    **funding_key.lamports.borrow_mut() = destination_starting_lamports + seat.lamports();
+    **seat.lamports.borrow_mut() = 0;
+    seat.assign(&solana_program::system_program::id());
+    seat.realloc(0, false)?;
+    phoenix_log!("Seat has been removed");
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub fn process_instruction(
         let seat = SeatAccountInfo::new(next_account_info(&mut accounts.iter())?, market.key)?;
         let funding_key = next_account_info(&mut accounts.iter())?;
 
-        if market.data_is_empty() && market.owner == solana_program::system_program::id() {
+        if market.data_is_empty() && *market.owner == solana_program::system_program::id() {
             phoenix_log!("Market is empty, reclaiming seat's lamports");
         } else {
             // There are other cases that fall into this category.
@@ -162,7 +162,7 @@ pub fn process_instruction(
         let destination_starting_lamports = funding_key.lamports();
         **funding_key.lamports.borrow_mut() = destination_starting_lamports + seat.lamports();
         **seat.lamports.borrow_mut() = 0;
-        seat.assign(&system_program::id());
+        seat.assign(&solana_program::system_program::id());
         seat.realloc(0, false)?;
         phoenix_log!("Seat has been removed");
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod quantities;
 mod shank_structs;
 pub mod state;
 
-use crate::program::processor::*;
+use crate::program::{checkers::phoenix_checkers::SeatAccountInfo, processor::*};
 
 use borsh::BorshSerialize;
 // You need to import Pubkey prior to using the declare_id macro
@@ -121,6 +121,47 @@ pub fn process_instruction(
             ProgramError::InvalidArgument,
             "Invalid log authority",
         )?;
+        return Ok(());
+    }
+
+    if let PhoenixInstruction::DeleteSeat = instruction {
+        let market = next_account_info(&mut accounts.iter())?;
+        let seat = SeatAccountInfo::new(next_account_info(&mut accounts.iter())?, market.key)?;
+        let funding_key = next_account_info(&mut accounts.iter())?;
+
+        if market.owner == &crate::id() {
+            // If the seat on the market is no longer owned by the Phoenix program, the market must have been closed
+            // We can safely reclaim all of the lamports from the seat
+            return Err(ProgramError::IllegalOwner);
+        }
+
+        let (trader, payer) = {
+            let seat = seat.load_mut()?;
+            (seat.trader, seat.funding_key)
+        };
+
+        if payer == Pubkey::default() {
+            phoenix_log!("Seat's lamports will be reclaimed to the trader");
+            assert_with_msg(
+                trader == *funding_key.key,
+                ProgramError::InvalidAccountData,
+                "Funding key mismatch",
+            )?;
+        } else {
+            phoenix_log!("Seat's lamports will be reclaimed to the funder");
+            assert_with_msg(
+                payer == *funding_key.key,
+                ProgramError::InvalidAccountData,
+                "Funding key mismatch",
+            )?;
+        }
+
+        let destination_starting_lamports = funding_key.lamports();
+        **funding_key.lamports.borrow_mut() = destination_starting_lamports + seat.lamports();
+        **seat.lamports.borrow_mut() = 0;
+        seat.assign(&system_program::id());
+        seat.realloc(0, false)?;
+        phoenix_log!("Seat has been removed");
         return Ok(());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,12 @@ pub fn process_instruction(
         let seat = SeatAccountInfo::new(next_account_info(&mut accounts.iter())?, market.key)?;
         let funding_key = next_account_info(&mut accounts.iter())?;
 
-        if market.owner == &crate::id() {
-            // If the seat on the market is no longer owned by the Phoenix program, the market must have been closed
-            // We can safely reclaim all of the lamports from the seat
+        if market.data_is_empty() {
+            phoenix_log!("Market is empty, reclaiming seat's lamports");
+        } else {
+            // There are other cases that fall into this category.
+            // All of those cases involve user misconfiguation, so we return an error out of caution.
+            phoenix_log!("Market is not empty, cannot reclaim seat's lamports");
             return Err(ProgramError::IllegalOwner);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ pub fn process_instruction(
     Ok(())
 }
 
-fn delete_seat_account(&accounts: &[AccountInfo]) -> ProgramResult {
+fn delete_seat_account(accounts: &[AccountInfo]) -> ProgramResult {
     let market = next_account_info(&mut accounts.iter())?;
     let seat = SeatAccountInfo::new(next_account_info(&mut accounts.iter())?, market.key)?;
     let funding_key = next_account_info(&mut accounts.iter())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub fn process_instruction(
         let seat = SeatAccountInfo::new(next_account_info(&mut accounts.iter())?, market.key)?;
         let funding_key = next_account_info(&mut accounts.iter())?;
 
-        if market.data_is_empty() {
+        if market.data_is_empty() && market.owner == solana_program::system_program::id() {
             phoenix_log!("Market is empty, reclaiming seat's lamports");
         } else {
             // There are other cases that fall into this category.

--- a/src/program/accounts.rs
+++ b/src/program/accounts.rs
@@ -144,7 +144,8 @@ pub struct Seat {
     pub trader: Pubkey,
     pub approval_status: u64,
     // Padding
-    _padding: [u64; 6],
+    pub funding_key: Pubkey,
+    _padding: [u64; 2],
 }
 
 impl ZeroCopy for Seat {}
@@ -156,7 +157,23 @@ impl Seat {
             market,
             trader,
             approval_status: SeatApprovalStatus::NotApproved as u64,
-            _padding: [0; 6],
+            funding_key: Pubkey::default(),
+            _padding: [0; 2],
+        })
+    }
+
+    pub fn new_with_funding_key(
+        market: Pubkey,
+        trader: Pubkey,
+        funding_key: Pubkey,
+    ) -> Result<Self, ProgramError> {
+        Ok(Self {
+            discriminant: get_discriminant::<Seat>()?,
+            market,
+            trader,
+            approval_status: SeatApprovalStatus::NotApproved as u64,
+            funding_key,
+            _padding: [0; 2],
         })
     }
 }

--- a/src/program/accounts.rs
+++ b/src/program/accounts.rs
@@ -151,18 +151,7 @@ pub struct Seat {
 impl ZeroCopy for Seat {}
 
 impl Seat {
-    pub fn new_init(market: Pubkey, trader: Pubkey) -> Result<Self, ProgramError> {
-        Ok(Self {
-            discriminant: get_discriminant::<Seat>()?,
-            market,
-            trader,
-            approval_status: SeatApprovalStatus::NotApproved as u64,
-            funding_key: Pubkey::default(),
-            _padding: [0; 2],
-        })
-    }
-
-    pub fn new_with_funding_key(
+    pub fn new_init(
         market: Pubkey,
         trader: Pubkey,
         funding_key: Pubkey,

--- a/src/program/instruction.rs
+++ b/src/program/instruction.rs
@@ -273,6 +273,11 @@ pub enum PhoenixInstruction {
     #[account(3, signer, name = "market_authority", desc = "The market_authority account must sign to change the free recipient")]
     #[account(4, name = "new_fee_recipient", desc = "New fee recipient")]
     ChangeFeeRecipient = 109,
+
+    #[account(0, name = "market", desc = "This account holds the market state")]
+    #[account(1, writable, name = "seat", desc = "The seat account to change the funding key")]
+    #[account(2, writable, name = "funding_key", desc = "The new funding key")]
+    DeleteSeat = 110,
 }
 
 impl PhoenixInstruction {
@@ -283,7 +288,7 @@ impl PhoenixInstruction {
 
 #[test]
 fn test_instruction_serialization() {
-    for i in 0..=108 {
+    for i in 0..=110 {
         let instruction = match PhoenixInstruction::try_from(i) {
             Ok(j) => j,
             Err(_) => {

--- a/src/program/instruction_builders/market_instructions.rs
+++ b/src/program/instruction_builders/market_instructions.rs
@@ -651,3 +651,19 @@ pub fn create_request_seat_instruction(payer: &Pubkey, market: &Pubkey) -> Instr
         data: PhoenixInstruction::RequestSeat.to_vec(),
     }
 }
+
+pub fn create_delete_seat_instruction(
+    market: &Pubkey,
+    seat: &Pubkey,
+    funding_key: &Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id: crate::id(),
+        accounts: vec![
+            AccountMeta::new_readonly(*market, false),
+            AccountMeta::new(*seat, false),
+            AccountMeta::new(*funding_key, false),
+        ],
+        data: PhoenixInstruction::DeleteSeat.to_vec(),
+    }
+}

--- a/src/program/processor/manage_seat.rs
+++ b/src/program/processor/manage_seat.rs
@@ -89,7 +89,7 @@ fn _create_seat<'a, 'info>(
     )?;
     let mut seat_bytes = seat.try_borrow_mut_data()?;
     *Seat::load_mut_bytes(&mut seat_bytes).ok_or(ProgramError::InvalidAccountData)? =
-        Seat::new_with_funding_key(*market_key, *trader, *payer.key)?;
+        Seat::new_init(*market_key, *trader, *payer.key)?;
     Ok(())
 }
 

--- a/src/program/processor/manage_seat.rs
+++ b/src/program/processor/manage_seat.rs
@@ -89,7 +89,7 @@ fn _create_seat<'a, 'info>(
     )?;
     let mut seat_bytes = seat.try_borrow_mut_data()?;
     *Seat::load_mut_bytes(&mut seat_bytes).ok_or(ProgramError::InvalidAccountData)? =
-        Seat::new_init(*market_key, *trader)?;
+        Seat::new_with_funding_key(*market_key, *trader, *payer.key)?;
     Ok(())
 }
 


### PR DESCRIPTION
The changes here are extremely small, all hand-written:

- Adds the funding key to the Seat account on creation. This allows rent to be reclaimed to the correct destination
- Adds a new instruction to reclaim the Seat's lamports to the correct funder
    - For legacy, if the funder is the system program, return to the trader
    - The seat's data is checked against the market key.
    - If the market's data is empty, the seat can safely be reclaimed
        - Note that there is an edge case where the previous Market Authority can intentionally cause UB here if they held on to the private key. This PR explicitly rejects seat cleanup in this case.