### PR TITLE
fix(idl): remove dead code block with typo in instruction name

### DIFF
--- a/idl/generateIdl.js
+++ b/idl/generateIdl.js
@@ -67,17 +67,6 @@ function mutateIdl() {
       });
     }
     if (
-      instruction.name === "CancelMulitpleOrdersById" ||
-      instruction.name === "CancelMulitpleOrdersByIdWithFreeFunds"
-    ) {
-      instruction.args.push({
-        name: "params",
-        type: {
-          defined: "CancelMulitpleOrdersByIdParams",
-        },
-      });
-    }
-    if (
       instruction.name === "PlaceLimitOrder" ||
       instruction.name === "PlaceLimitOrderWithFreeFunds" ||
       instruction.name === "Swap" ||


### PR DESCRIPTION
- Removed unreachable code checking for `CancelMulitpleOrdersById` (typo)
- The correct `CancelMultipleOrdersById` handling remains intact
- No functional changes, just dead code removal